### PR TITLE
Fix distributed training/tournament mode

### DIFF
--- a/pypolygames/utils/result.py
+++ b/pypolygames/utils/result.py
@@ -16,7 +16,7 @@ def parse_reward(reward):
         else:
             result["tie"] += 1
     result["total"] = len(reward)
-    result["avg"] = (sum(reward) / (len(reward) + 1.)) / 2.
+    result["avg"] = (sum(reward) / max(len(reward), 1) + 1.) / 2.
     return result
 
 

--- a/pypolygames/utils/result.py
+++ b/pypolygames/utils/result.py
@@ -16,7 +16,7 @@ def parse_reward(reward):
         else:
             result["tie"] += 1
     result["total"] = len(reward)
-    result["avg"] = (sum(reward) / len(reward) + 1.) / 2.
+    result["avg"] = (sum(reward) / (len(reward) + 1.)) / 2.
     return result
 
 
@@ -26,10 +26,11 @@ class Result:
         self.result = parse_reward(reward)
 
     def log(self):
+        total = max(self.result["total"], 1)
         s = "win: %.2f, tie: %.2f, loss: %.2f, avg: %.2f" % (
-            100 * self.result["win"] / self.result["total"],
-            100 * self.result["tie"] / self.result["total"],
-            100 * self.result["loss"] / self.result["total"],
+            100 * self.result["win"] / total,
+            100 * self.result["tie"] / total,
+            100 * self.result["loss"] / total,
             100 * self.result["avg"],
         )
         return s

--- a/torchRL/mcts/actor.h
+++ b/torchRL/mcts/actor.h
@@ -39,6 +39,9 @@ class Actor {
   virtual void terminate() {
   }
 
+  virtual void recordMove(const mcts::State* state) {
+  }
+
   virtual void result(const State* state, float reward) {
   }
 

--- a/torchRL/mcts/mcts.h
+++ b/torchRL/mcts/mcts.h
@@ -48,6 +48,10 @@ class MctsPlayer : public Player {
   void newEpisode() override {
   }
 
+  void recordMove(const State* state) override {
+    actors_[0]->recordMove(state);
+  }
+
   void result(const State* state, float reward) override {
     actors_[0]->result(state, reward);
   }

--- a/torchRL/mcts/player.h
+++ b/torchRL/mcts/player.h
@@ -29,6 +29,8 @@ class Player {
   }
   virtual void newEpisode() {
   }
+  virtual void recordMove(const State* state) {
+  }
   virtual void result(const State*, float reward) {
   }
 


### PR DESCRIPTION
## Types of changes

This fixes an issue with the tournament-mode simply not working.
May resolve issues people were having with running distributed trainings.

The issue is related to how evaluate and result are passed different state pointers for the same game state. This pointer is used to track which model was being used to make a move in the game so that the correct results can be sent to the server. Now, this pointer is tracked in a new recordMove call, which is passed the same state pointer as result.

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## How Has This Been Tested (if it applies)

Ran a small distributed training on hex5, which it seemed to solve (beats random model, seems to play optimally in vs human mode).

