### PR TITLE
Support pytorch 1.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,12 @@ set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-register -fPIC -march=native -O3 -Wfatal-errors")
 
 OPTION(PYTORCH12 "Is PyTorch >= 1.2" OFF)
-IF(PYTORCH12)
+OPTION(PYTORCH15 "Is PyTorch >= 1.5" OFF)
+IF(PYTORCH15)
+    ADD_DEFINITIONS(-DPYTORCH15 -DPYTORCH12)
+ELSEIF(PYTORCH12)
     ADD_DEFINITIONS(-DPYTORCH12)
-ENDIF(PYTORCH12)
+ENDIF()
 
 execute_process(
     COMMAND python -c "import torch; import os; print(os.path.dirname(torch.__file__), end='')"


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

This adds support for pytorch 1.5 enabled with a PYTORCH15 option to correspond with the existing PYTORCH12 option. Pytorch 1.4 will probably work too, as the change is very small, but 1.5 seems like a better release to target as they have a stable c++ API now (though we only use a small part of it).

We should perhaps move to pytorch 1.5 as the default, but I did not make it default for now.

Models trained in pytorch 1.1 will need to be converted to work in pytorch 1.5, but AFAIK the only change is in train/eval vars which have no impact on the model.

Note that the way we define our models directly as script modules is actually deprecated in pytorch 1.5, and throws some warnings, but does still work (and has the same behavior as the recommended method).