### PR TITLE
Autotune game batch size, async forwards

### DIFF
--- a/core/actor.h
+++ b/core/actor.h
@@ -123,8 +123,8 @@ class Actor : public mcts::Actor {
             *dynamic_cast<const State*>(s[i]), featAcc[i].data());
       }
       double t = assembler_->batchAct(batchFeat_.slice(0, 0, s.size()),
-                           batchValue_.slice(0, 0, s.size()),
-                           batchPi_.slice(0, 0, s.size()));
+                                      batchValue_.slice(0, 0, s.size()),
+                                      batchPi_.slice(0, 0, s.size()));
       batchTiming_ = batchTiming_ * 0.99 + t * 0.01;
     }
 

--- a/core/game.cc
+++ b/core/game.cc
@@ -120,7 +120,6 @@ void Game::mainLoop() {
 
     std::vector<std::pair<size_t, size_t>> statePlayerSize;
 
-    bool hasOvershotBatchsize = false;
     double batchLr = 1.0;
 
     while (!states.empty() && !terminate_) {
@@ -148,7 +147,6 @@ void Game::mainLoop() {
           }
         }
         if (adjust < -0.05) {
-          hasOvershotBatchsize = true;
           if (ngames > 1) {
             --ngames;
           }

--- a/core/game.cc
+++ b/core/game.cc
@@ -206,17 +206,19 @@ void Game::mainLoop() {
             for (size_t idx = 0; idx != players_.size(); ++idx) {
               result_.at(idx) = int(idx) == i->resigned ? -1 : 1;
             }
-            //fmt::printf("player %d (%s) resigned : %s\n", i->resigned,
-            //            players_.at(i->resigned)->getName(), state->history());
+            // fmt::printf("player %d (%s) resigned : %s\n", i->resigned,
+            //            players_.at(i->resigned)->getName(),
+            //            state->history());
           } else {
             for (size_t idx = 0; idx != players_.size(); ++idx) {
               result_[idx] = state->getReward(idx);
             }
-            //fmt::printf("game ended normally: %s\n", state->history().c_str());
+            // fmt::printf("game ended normally: %s\n",
+            // state->history().c_str());
           }
 
           for (size_t p = 0; p != players_.size(); ++p) {
-            //fmt::printf(
+            // fmt::printf(
             //    "Result for %s: %g\n", players_[p]->getName(), result_[p]);
             for (auto& v : i->feat[p]) {
               feature_[p].pushBack(v);

--- a/pypolygames/params.py
+++ b/pypolygames/params.py
@@ -295,7 +295,7 @@ class SimulationParams:
     replay_warmup: int = 10_000
     sync_period: int = 100
     act_batchsize: int = 1
-    per_thread_batchsize: int = 0
+    per_thread_batchsize: int = -1
     train_channel_timeout_ms: int = 1
     train_channel_num_slots: int = 1000
 
@@ -356,7 +356,8 @@ class SimulationParams:
                     type=int,
                     help="When non-zero, "
                     "number of games in each game-running threads run sequentially "
-                    "and batched together for inference (see '--act_batchsize')",
+                    "and batched together for inference (see '--act_batchsize'). "
+                    "This parameter will be automatically tuned if it is negative",
                 )
             ),
             train_channel_timeout_ms=ArgFields(

--- a/pypolygames/training.py
+++ b/pypolygames/training.py
@@ -122,7 +122,7 @@ def create_training_environment(
               eval_mode=False,
               per_thread_batchsize=simulation_params.per_thread_batchsize,
           )
-          if simulation_params.per_thread_batchsize > 0:
+          if simulation_params.per_thread_batchsize != 0:
               player_1 = create_player(
                   seed_generator=seed_generator,
                   game=game,

--- a/torchRL/mcts/actor.h
+++ b/torchRL/mcts/actor.h
@@ -48,6 +48,10 @@ class Actor {
   virtual bool isTournamentOpponent() const {
     return false;
   }
+
+  virtual double batchTiming() const {
+    return -1.0f;
+  }
 };
 
 }  // namespace mcts

--- a/torchRL/mcts/mcts.h
+++ b/torchRL/mcts/mcts.h
@@ -60,7 +60,7 @@ class MctsPlayer : public Player {
     return actors_[0]->isTournamentOpponent();
   }
 
-  double batchTiming() const{
+  double batchTiming() const {
     return actors_[0]->batchTiming();
   }
 

--- a/torchRL/mcts/mcts.h
+++ b/torchRL/mcts/mcts.h
@@ -60,6 +60,10 @@ class MctsPlayer : public Player {
     return actors_[0]->isTournamentOpponent();
   }
 
+  double batchTiming() const{
+    return actors_[0]->batchTiming();
+  }
+
   std::vector<MctsResult> actMcts(const std::vector<const State*>& states) {
     std::vector<MctsResult> result(states.size(), &rng_);
 


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This will now by default automatically tune the --per_thread_batchsize option. It can still be set to disable this behavior (default is -1 which enables auto tuning).

The way it works is by doing the forwards asynchronously, then timing the synchronize call, and trying to optimize batchsize such that the synchronize takes 1 millisecond - this would indicate that the batch size is large enough for the gpu time to take longer than the cpu time of the forward itself, and experimentally seems reasonable.

In practice we want small batch sizes, since it reduces the latency/real time it takes for games to complete, but we also want a high throughput/as many games running as possible, which is best attainable with large batch sizes. This seeks to reach some middle ground.

