### PR TITLE
Fix for Ludii's class paths

### DIFF
--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -66,10 +66,10 @@ void JNIUtils::InitJVM(std::string jar_location) {
 #endif /* JNI_VERSION_1_2 */
 
 	// Find our LudiiGameWrapper Java class
-	ludiiGameWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("player/utils/LudiiGameWrapper"));
+	ludiiGameWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("player/utils/supplementary/LudiiGameWrapper"));
 
 	// Find our LudiiStateWrapper Java class
-	ludiiStateWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("player/utils/LudiiStateWrapper"));
+	ludiiStateWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("player/utils/supplementary/LudiiStateWrapper"));
 }
 
 void JNIUtils::CloseJVM() {

--- a/games/ludii/ludii_state_wrapper.cc
+++ b/games/ludii/ludii_state_wrapper.cc
@@ -155,7 +155,7 @@ LudiiStateWrapper::LudiiStateWrapper(int seed, JNIEnv* jenv, LudiiGameWrapper &&
 
 	// Find the LudiiStateWrapper Java constructor
 	jmethodID ludiiStateWrapperConstructor =
-			jenv->GetMethodID(ludiiStateWrapperClass, "<init>", "(Lplayer/utils/LudiiGameWrapper;)V");
+			jenv->GetMethodID(ludiiStateWrapperClass, "<init>", "(Lplayer/utils/supplementary/LudiiGameWrapper;)V");
 
 	// Call our Java constructor to instantiate new object
 	ludiiStateWrapperJavaObject =
@@ -179,7 +179,7 @@ LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
 
 	// Find the LudiiStateWrapper Java copy constructor
 	jmethodID ludiiStateWrapperCopyConstructor =
-			jenv->GetMethodID(ludiiStateWrapperClass, "<init>", "(Lplayer/utils/LudiiStateWrapper;)V");
+			jenv->GetMethodID(ludiiStateWrapperClass, "<init>", "(Lplayer/utils/supplementary/LudiiStateWrapper;)V");
 
 	// Call our Java constructor to instantiate new object
 	ludiiStateWrapperJavaObject =


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The Ludii-related unit test failed at Circle CI. This should probably fix it. The issue is that we've (in the past couple weeks somewhere) uploaded new versions of Ludii.jar to our website, and in one of these two of the Ludii classes that Polygames tries to load dynamically through JNI got moved into a new package. So the fully qualified class names for these two needed to be updated in the Polygames code.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

Can successfully run `./build/test_state` again without crashing (locally).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
