### PR TITLE
Ludii v0.9.4

### DIFF
--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -70,6 +70,11 @@ void JNIUtils::InitJVM(std::string jar_location) {
 
 	// Find our LudiiStateWrapper Java class
 	ludiiStateWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("utils/LudiiStateWrapper"));
+
+	// Find the method ID for the static method giving us the Ludii versio
+	ludiiVersionMethodID = env->GetStaticMethodID(ludiiGameWrapperClass, "ludiiVersion", "()Ljava/lang/String;");
+
+	std::cout << "Using Ludii version " << LudiiVersion() << std::endl;
 }
 
 void JNIUtils::CloseJVM() {
@@ -85,6 +90,7 @@ void JNIUtils::CloseJVM() {
 // These will be assigned proper values by InitJVM() call
 jclass JNIUtils::ludiiGameWrapperClass = nullptr;
 jclass JNIUtils::ludiiStateWrapperClass = nullptr;
+jmethodID JNIUtils::ludiiVersionMethodID = nullptr;
 
 jclass JNIUtils::LudiiGameWrapperClass() {
 	return ludiiGameWrapperClass;
@@ -92,6 +98,14 @@ jclass JNIUtils::LudiiGameWrapperClass() {
 
 jclass JNIUtils::LudiiStateWrapperClass() {
 	return ludiiStateWrapperClass;
+}
+
+const std::string JNIUtils::LudiiVersion() {
+	jstring jstr = (jstring) (env->CallStaticObjectMethod(ludiiGameWrapperClass, ludiiVersionMethodID));
+	const char* strReturn = env->GetStringUTFChars(jstr, (jboolean*) 0);
+	const std::string str = strReturn;
+	env->ReleaseStringUTFChars(jstr, strReturn);
+	return str;
 }
 
 }  // namespace Ludii

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -66,10 +66,10 @@ void JNIUtils::InitJVM(std::string jar_location) {
 #endif /* JNI_VERSION_1_2 */
 
 	// Find our LudiiGameWrapper Java class
-	ludiiGameWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("player/utils/supplementary/LudiiGameWrapper"));
+	ludiiGameWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("utils/LudiiGameWrapper"));
 
 	// Find our LudiiStateWrapper Java class
-	ludiiStateWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("player/utils/supplementary/LudiiStateWrapper"));
+	ludiiStateWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("utils/LudiiStateWrapper"));
 }
 
 void JNIUtils::CloseJVM() {

--- a/games/ludii/jni_utils.h
+++ b/games/ludii/jni_utils.h
@@ -42,6 +42,11 @@ class JNIUtils {
   static jclass LudiiGameWrapperClass();
   static jclass LudiiStateWrapperClass();
 
+  /**
+   * @return A string description of the version of Ludii that we're working with.
+   */
+  static const std::string LudiiVersion();
+
  private:
   static JavaVM *jvm;
   static JNIEnv *env;
@@ -52,6 +57,9 @@ class JNIUtils {
 
   /** Our LudiiStateWrapper class in Java */
   static jclass ludiiStateWrapperClass;
+
+  /** Method ID for the ludiiVersion() method in Java */
+  static jmethodID ludiiVersionMethodID;
 };
 
 }  // namespace Ludii

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -69,6 +69,9 @@ LudiiGameWrapper::LudiiGameWrapper(
 	// Find method IDs for the two tensor shape Java methods that we may be calling frequently
 	stateTensorsShapeMethodID = jenv->GetMethodID(ludiiGameWrapperClass, "stateTensorsShape", "()[I");
 	moveTensorsShapeMethodID = jenv->GetMethodID(ludiiGameWrapperClass, "moveTensorsShape", "()[I");
+
+	// Find the method ID for the stateTensorChannelNames() method in Java
+	stateTensorChannelNamesMethodID = jenv->GetMethodID(ludiiGameWrapperClass, "stateTensorChannelNames", "()[Ljava/lang/String;");
 }
 
 LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other)

--- a/games/ludii/ludii_state_wrapper.cc
+++ b/games/ludii/ludii_state_wrapper.cc
@@ -155,7 +155,7 @@ LudiiStateWrapper::LudiiStateWrapper(int seed, JNIEnv* jenv, LudiiGameWrapper &&
 
 	// Find the LudiiStateWrapper Java constructor
 	jmethodID ludiiStateWrapperConstructor =
-			jenv->GetMethodID(ludiiStateWrapperClass, "<init>", "(Lplayer/utils/supplementary/LudiiGameWrapper;)V");
+			jenv->GetMethodID(ludiiStateWrapperClass, "<init>", "(Lutils/LudiiGameWrapper;)V");
 
 	// Call our Java constructor to instantiate new object
 	ludiiStateWrapperJavaObject =
@@ -179,7 +179,7 @@ LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
 
 	// Find the LudiiStateWrapper Java copy constructor
 	jmethodID ludiiStateWrapperCopyConstructor =
-			jenv->GetMethodID(ludiiStateWrapperClass, "<init>", "(Lplayer/utils/supplementary/LudiiStateWrapper;)V");
+			jenv->GetMethodID(ludiiStateWrapperClass, "<init>", "(Lutils/LudiiStateWrapper;)V");
 
 	// Call our Java constructor to instantiate new object
 	ludiiStateWrapperJavaObject =


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Yesterday a new version of Ludii, 0.9.4, was uploaded to Ludii's website. In this version, the two Java classes that Polygames dynamically loads through JNI were moved to a different package again (hopefully for the last time!), which means that this code in Polygames needs to be updated to correctly refer to the new packages.

When initialising the JVM and Ludii stuff in Polygames, I have also added a print message that now prints the version of Ludii that we're using. 

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

- Downloaded the new version of `Ludii.jar` from `ludii.games/downloads/Ludii.jar`, and placed it in `Polygames/ludii`.
- Ran `./build/test_state`, which passed.
- Ran `python -m pypolygames train --game_name="LudiiTic-Tac-Toe.lud"`, which could run successfully on my own machine (at least for a few minutes -- then it ran out of memory. I'm not sure yet if that is to be expected for this command on my own personal machine, or if this is indicative of a memory leak somewhere, but I doubt it would be new due to any of the changes in this PR).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
