### PR TITLE
Fix time counting

### DIFF
--- a/core/game.cc
+++ b/core/game.cc
@@ -304,15 +304,23 @@ void Game::mainLoop() {
     }
   } else {
 
-    // Warm up model. This can take several seconds, so do it before we start
-    // time counting.
+    // Warm up JIT/model. This can take several seconds, so do it before we
+    // start time counting.
     for (auto& v : players_) {
       auto mctsPlayer = std::dynamic_pointer_cast<mcts::MctsPlayer>(v);
       if (mctsPlayer && mctsPlayer->option().totalTime) {
         std::cout << "Warming up model.\n";
-        for (int i = 0; i != 10; ++i) {
-          mctsPlayer->calculateValue(*state_);
-        }
+        auto opt = mctsPlayer->option();
+        mctsPlayer->option().totalTime = 0;
+        mctsPlayer->option().numRolloutPerThread = 20;
+        mctsPlayer->reset();
+        mctsPlayer->actMcts(*state_);
+        mctsPlayer->actMcts(*state_);
+        mctsPlayer->actMcts(*state_);
+        mctsPlayer->actMcts(*state_);
+
+        mctsPlayer->option() = opt;
+        mctsPlayer->reset();
       }
     }
 

--- a/core/game.cc
+++ b/core/game.cc
@@ -463,6 +463,9 @@ std::optional<int> Game::parseSpecialAction(const std::string& str) {
         return -1;
       } else if (str == "r" || str == "reset") {
         state_->reset();
+        for (auto& v : players_) {
+          v->reset();
+        }
         return -1;
       } else if (str == "u" || str == "undo") {
         state_->undoLastMove();

--- a/core/game.cc
+++ b/core/game.cc
@@ -304,6 +304,18 @@ void Game::mainLoop() {
     }
   } else {
 
+    // Warm up model. This can take several seconds, so do it before we start
+    // time counting.
+    for (auto& v : players_) {
+      auto mctsPlayer = std::dynamic_pointer_cast<mcts::MctsPlayer>(v);
+      if (mctsPlayer && mctsPlayer->option().totalTime) {
+        std::cout << "Warming up model.\n";
+        for (int i = 0; i != 10; ++i) {
+          mctsPlayer->calculateValue(*state_);
+        }
+      }
+    }
+
     int64_t gameCount = 0;
 #ifdef DEBUG_GAME
     std::thread::id thread_id = std::this_thread::get_id();

--- a/core/state.h
+++ b/core/state.h
@@ -156,7 +156,9 @@ class State : public mcts::State {
     auto rngs = _moveRngs;
     s->reset();
     for (size_t i = 0; i != moves.size(); ++i) {
-      // if (!str.empty()) str += " ";
+      if (!str.empty()) {
+        str += " ";
+      }
       str += s->actionDescription(*s->GetLegalActions().at(moves.at(i)));
       std::tie(s->_rng, s->forcedDice) = rngs.at(i);
       s->forward(moves.at(i));

--- a/core/state.h
+++ b/core/state.h
@@ -319,20 +319,20 @@ class State : public mcts::State {
   }
 
   virtual std::string actionsDescription() {
-    std::stringstream ss;
-    for (int i = 0; i < (int)_legalActions.size(); i++) {
-      _Action& action = *(_legalActions[i]);
-      ss << "Action " << i << ": " << actionDescription(action) << std::endl;
+    std::string str;
+    for (auto& v : _legalActions) {
+      str += actionDescription(*v) + " ";
     }
-    return ss.str();
+    return str;
   }
 
   virtual int parseAction(const std::string& str) {
-    try {
-      return std::stoul(str, nullptr, 10);
-    } catch (...) {
-      return -1;
+    for (size_t i = 0; i != _legalActions.size(); ++i) {
+      if (str == actionDescription(*_legalActions[i])) {
+        return i;
+      }
     }
+    return -1;
   }
 
   int TPInputAction(

--- a/torchRL/mcts/mcts.cc
+++ b/torchRL/mcts/mcts.cc
@@ -91,8 +91,8 @@ void mcts::computeRollouts(const std::vector<Node*>& rootNode,
   double elapsedTime = 0;
   auto begin = std::chrono::steady_clock::now();
 
-  while ((((max_time > 0) || (numRollout < option.numRolloutPerThread)) &&
-          ((elapsedTime < max_time) || (max_time <= 0))) ||
+  while ((option.totalTime ? elapsedTime < max_time
+                           : numRollout < option.numRolloutPerThread) ||
          numRollout < 2) {
     // std::cout << " new rollout
     // ===================================================" << std::endl;
@@ -210,6 +210,8 @@ void mcts::computeRollouts(const std::vector<Node*>& rootNode,
     ++numRollout;
     auto end = std::chrono::steady_clock::now();
     elapsedTime =
-        std::chrono::duration_cast<std::chrono::seconds>(end - begin).count();
+        std::chrono::duration_cast<
+            std::chrono::duration<double, std::ratio<1, 1>>>(end - begin)
+            .count();
   }
 }

--- a/torchRL/mcts/mcts.h
+++ b/torchRL/mcts/mcts.h
@@ -89,12 +89,16 @@ class MctsPlayer : public Player {
       }
 
       double thisMoveTime = remaining_time * option_.timeRatio;
+      bool forceSingleActor = false;
       if (option_.totalTime > 0) {
         std::cerr << "Remaining time:" << remaining_time << std::endl;
         std::cerr << "This move time:" << thisMoveTime << std::endl;
+        if (remaining_time < 1 || thisMoveTime < 0.25) {
+          forceSingleActor = true;
+        }
       }
       auto begin = std::chrono::steady_clock::now();
-      if (actors_.size() == 1) {
+      if (actors_.size() == 1 || forceSingleActor) {
         computeRollouts(
             roots, states, *actors_[0], option_, thisMoveTime, rng_);
       } else {

--- a/torchRL/mcts/mcts.h
+++ b/torchRL/mcts/mcts.h
@@ -174,6 +174,15 @@ class MctsPlayer : public Player {
     return rolloutsPerSecond_;
   }
 
+  const MctsOption& option() {
+    return option_;
+  }
+
+  float calculateValue(const State& state) {
+    PiVal result =actors_.at(0)->evaluate(state);
+    return result.value;
+  }
+
  private:
   MctsOption option_;
   double remaining_time;

--- a/torchRL/mcts/mcts.h
+++ b/torchRL/mcts/mcts.h
@@ -182,7 +182,11 @@ class MctsPlayer : public Player {
     return rolloutsPerSecond_;
   }
 
-  const MctsOption& option() {
+  MctsOption& option() {
+    return option_;
+  }
+
+  const MctsOption& option() const {
     return option_;
   }
 

--- a/torchRL/mcts/mcts.h
+++ b/torchRL/mcts/mcts.h
@@ -40,11 +40,15 @@ class MctsPlayer : public Player {
       , option_(option)
       , rng_(option.seed)
       , storage_(option.storageCap) {
-    remaining_time = option.totalTime;
+    reset();
   }
 
   void addActor(std::shared_ptr<Actor> actor) {
     actors_.push_back(actor);
+  }
+
+  virtual void reset() override {
+    remaining_time = option_.totalTime;
   }
 
   void newEpisode() override {

--- a/torchRL/mcts/player.h
+++ b/torchRL/mcts/player.h
@@ -27,6 +27,8 @@ class Player {
 
   virtual void terminate() {
   }
+  virtual void reset() {
+  }
   virtual void newEpisode() {
   }
   virtual void recordMove(const State* state) {


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The time counting had some serious issues
  - integer rounding made us only count whole seconds (in turn we would run out of time quickly)
  - behavior would fall back to num_rollouts if we ran out of time

This fixes both.

I also included a small change that will warm up the model before the mcts starts. Since the first (couple of?) forwards take quite long as the JIT needs to load the model, we now do this before the game starts, so we don't count the time spent loading the model towards the time used.