### PR TITLE
Better breakthrough action/state description

### DIFF
--- a/games/breakthrough_state.h
+++ b/games/breakthrough_state.h
@@ -17,6 +17,9 @@
 //#include "game.h"
 #include "../core/state.h"
 
+
+#include "fmt/printf.h"
+
 const int StateForBreakthroughNumActions = 64 * 3;
 const int StateForBreakthroughX = 2;
 const int StateForBreakthroughY = 8;
@@ -46,21 +49,6 @@ class StateForBreakthrough : public State, BTBoard {
 
   virtual ~StateForBreakthrough() {
   }
-
-  int parseAction(const std::string& str) {
-  int x = int(str[0]) - 48;
-  int y = int(str[1]) - 48;
-  int z = int(str[2]) - 48;
-  try {
-    for (unsigned k=0; k<_legalActions.size(); k++)
-      if (_legalActions[k]->GetX() == x and _legalActions[k]->GetY() == y and _legalActions[k]->GetZ() == z)
-        return k;
-  }
-  catch (...) {
-    std::cout << "failed to parse action" << std::endl;
-  }
-  return -1;
-}
 
   virtual void Initialize() override {
     // People implementing classes should not have much to do in _moves; just
@@ -103,6 +91,29 @@ class StateForBreakthrough : public State, BTBoard {
 
   virtual std::unique_ptr<mcts::State> clone_() const override {
     return std::make_unique<StateForBreakthrough>(*this);
+  }
+
+  virtual int parseAction(const std::string& str) {
+    for (size_t i = 0; i != _legalActions.size(); ++i) {
+      if (str == actionDescription(*_legalActions[i])) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  std::string actionDescription(const _Action &action) const override {
+    int dir = action.GetX();
+    int x = action.GetY();
+    int y = action.GetZ();
+    int tx = x;
+    int ty = y + (turn == Black ? 1 : -1);
+    if (dir == 0) {
+      --tx;
+    } else if (dir == 2) {
+      ++tx;
+    }
+    return fmt::sprintf("%c%d%c%d", 'a' + x, BTDy - y , 'a' + tx, BTDy - ty);
   }
 
   void findActions(int color) {
@@ -204,9 +215,9 @@ class StateForBreakthrough : public State, BTBoard {
   }
 
   std::string stateDescription() const override {
-    std::string s (" 0 1 2 3 4 5 6 7\n");
+    std::string s;
     for (int i = 0; i < BTDy; i++) {
-      s += std::to_string (i);
+      s += std::to_string(BTDy - i);
       for (int j = 0; j < BTDx; j++)
         if (board[j][i] == Empty)
           s += " +";
@@ -216,7 +227,7 @@ class StateForBreakthrough : public State, BTBoard {
           s += " O";
       s += " \n";
     }
-    s += " \n";
+    s += "  a b c d e f g h \n";
     return s;
   }
 };


### PR DESCRIPTION
This will print and parse breakthrough actions in long algebraic notation, which is used on littlegolem and seems to be the standard

eg e2e3 for a move from e2 to e3

This does break the littlegolem script, will have to fix it later
It also orients the board correctly, like a chess board

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
