### PR TITLE
restore original parseAction (index)

### DIFF
--- a/core/state.h
+++ b/core/state.h
@@ -327,12 +327,11 @@ class State : public mcts::State {
   }
 
   virtual int parseAction(const std::string& str) {
-    for (size_t i = 0; i != _legalActions.size(); ++i) {
-      if (str == actionDescription(*_legalActions[i])) {
-        return i;
-      }
+    try {
+      return std::stoul(str, nullptr, 10);
+    } catch (...) {
+      return -1;
     }
-    return -1;
   }
 
   int TPInputAction(


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I made the mistake of changing the default parseAction - while the change should be made, some games need to be updated with a better actionDescription first.
