### PR TITLE
Dont test for duplicate actions

### DIFF
--- a/core/test_state.cc
+++ b/core/test_state.cc
@@ -76,18 +76,6 @@ int doSimpleTest(State& s) {
       }
       // s.stateDescription();
       // std::cout << "old:" << u << ":" << s.GetFeatures() << std::endl;
-      auto legalActions = s.GetLegalActions();
-      for (int i = 0; i < (int)legalActions.size(); i++) {
-        for (int j = i + 1; j < (int)legalActions.size(); j++) {
-          if ((legalActions[i]->GetX() == legalActions[j]->GetX()) &&
-              (legalActions[i]->GetY() == legalActions[j]->GetY()) &&
-              (legalActions[i]->GetZ() == legalActions[j]->GetZ())) {
-            cout << legalActions[i]->GetX() << "," << legalActions[i]->GetY()
-                 << "," << legalActions[i]->GetZ() << endl;
-            throw std::runtime_error("two identical actions");
-          }
-        }
-      }
     }
     // std::cerr << s.stateDescription() << std::endl;
     auto oldFeatures = s.GetFeatures();


### PR DESCRIPTION
As it is in fact legal for two actions to share action output location. They should still be separate actions in the game implementation, but the mcts will disambiguate them.

This should fix the CI again...