### PR TITLE
Gracefully handling absence of Ludii.jar file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@
 version: 2
 jobs:
   build:
+    branches:
+      ignore:
+        - dennis-tests
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@
 #
 version: 2
 jobs:
-  branches:
-    ignore:
-      - dennis-tests
   build:
+    branches:
+      ignore:
+        - dennis-tests
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@
 #
 version: 2
 jobs:
+  branches:
+    ignore:
+      - dennis-tests
   build:
     docker:
       # specify the version you desire here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,6 @@
 version: 2
 jobs:
   build:
-    branches:
-      ignore:
-        - dennis-tests
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`

--- a/core/game.h
+++ b/core/game.h
@@ -233,16 +233,16 @@ to look into this) if the strategy is identical to knuth’s.
       std::string ludii_name = gameName.substr(5);
       Ludii::JNIUtils::InitJVM("");  // Use default /ludii/Ludii.jar path
       JNIEnv* jni_env = Ludii::JNIUtils::GetEnv();
-	  
-	  if (jni_env) {
-		Ludii::LudiiGameWrapper game_wrapper(jni_env, ludii_name);
-		state_ = std::make_unique<Ludii::LudiiStateWrapper>(
-	      seed, jni_env, std::move(game_wrapper));
-	  }
-	  else {
-		  // Probably means we couldn't find the Ludii.jar file
-		  throw std::runtime_error("Failed to create Ludii game due to missing JNI Env!");
-	  }
+
+      if (jni_env) {
+        Ludii::LudiiGameWrapper game_wrapper(jni_env, ludii_name);
+        state_ = std::make_unique<Ludii::LudiiStateWrapper>(
+            seed, jni_env, std::move(game_wrapper));
+      } else {
+        // Probably means we couldn't find the Ludii.jar file
+        throw std::runtime_error(
+            "Failed to create Ludii game due to missing JNI Env!");
+      }
 #endif
     } else if (isGameNameMatched({"Tristannogo"})) {
       state_ = std::make_unique<StateForTristannogo>(seed);

--- a/core/game.h
+++ b/core/game.h
@@ -233,9 +233,16 @@ to look into this) if the strategy is identical to knuth’s.
       std::string ludii_name = gameName.substr(5);
       Ludii::JNIUtils::InitJVM("");  // Use default /ludii/Ludii.jar path
       JNIEnv* jni_env = Ludii::JNIUtils::GetEnv();
-      Ludii::LudiiGameWrapper game_wrapper(jni_env, ludii_name);
-      state_ = std::make_unique<Ludii::LudiiStateWrapper>(
-          seed, jni_env, std::move(game_wrapper));
+	  
+	  if (jni_env) {
+		Ludii::LudiiGameWrapper game_wrapper(jni_env, ludii_name);
+		state_ = std::make_unique<Ludii::LudiiStateWrapper>(
+	      seed, jni_env, std::move(game_wrapper));
+	  }
+	  else {
+		  // Probably means we couldn't find the Ludii.jar file
+		  throw std::runtime_error("Failed to create Ludii game due to missing JNI Env!");
+	  }
 #endif
     } else if (isGameNameMatched({"Tristannogo"})) {
       state_ = std::make_unique<StateForTristannogo>(seed);

--- a/core/test_state.cc
+++ b/core/test_state.cc
@@ -150,11 +150,17 @@ int main() {
     std::cout << "testing: Ludii Tic-Tac-Toe" << std::endl;
     Ludii::JNIUtils::InitJVM("");  // Use default /ludii/Ludii.jar path
     JNIEnv* jni_env = Ludii::JNIUtils::GetEnv();
-    Ludii::LudiiGameWrapper game_wrapper(jni_env, "Tic-Tac-Toe.lud");
-    auto state = std::make_unique<Ludii::LudiiStateWrapper>(seed, jni_env, std::move(game_wrapper));    
-    doTest(*state);
-    Ludii::JNIUtils::CloseJVM();
-    std::cout << "test pass: Ludii Tic-Tac-Toe" << std::endl;
+	
+	if (jni_env) {
+		Ludii::LudiiGameWrapper game_wrapper(jni_env, "Tic-Tac-Toe.lud");
+		auto state = std::make_unique<Ludii::LudiiStateWrapper>(seed, jni_env, std::move(game_wrapper));    
+		doTest(*state);
+		Ludii::JNIUtils::CloseJVM();
+		std::cout << "test pass: Ludii Tic-Tac-Toe" << std::endl;
+	}
+	else {
+		std::cout << "skipping: Ludii Tic-Tac-Toe" << std::endl;
+	}
 #endif
   }
   

--- a/core/test_state.cc
+++ b/core/test_state.cc
@@ -150,20 +150,20 @@ int main() {
     std::cout << "testing: Ludii Tic-Tac-Toe" << std::endl;
     Ludii::JNIUtils::InitJVM("");  // Use default /ludii/Ludii.jar path
     JNIEnv* jni_env = Ludii::JNIUtils::GetEnv();
-	
-	if (jni_env) {
-		Ludii::LudiiGameWrapper game_wrapper(jni_env, "Tic-Tac-Toe.lud");
-		auto state = std::make_unique<Ludii::LudiiStateWrapper>(seed, jni_env, std::move(game_wrapper));    
-		doTest(*state);
-		Ludii::JNIUtils::CloseJVM();
-		std::cout << "test pass: Ludii Tic-Tac-Toe" << std::endl;
-	}
-	else {
-		std::cout << "skipping: Ludii Tic-Tac-Toe" << std::endl;
-	}
+
+    if (jni_env) {
+      Ludii::LudiiGameWrapper game_wrapper(jni_env, "Tic-Tac-Toe.lud");
+      auto state = std::make_unique<Ludii::LudiiStateWrapper>(
+          seed, jni_env, std::move(game_wrapper));
+      doTest(*state);
+      Ludii::JNIUtils::CloseJVM();
+      std::cout << "test pass: Ludii Tic-Tac-Toe" << std::endl;
+    } else {
+      std::cout << "skipping: Ludii Tic-Tac-Toe" << std::endl;
+    }
 #endif
   }
-  
+
   {
     std::cout << "testing: connect four" << std::endl;
     auto state = StateForConnectFour(seed);
@@ -291,42 +291,42 @@ int main() {
 
   {
     std::cout << "testing: havannah5pieExt" << std::endl;
-    auto state = Havannah::State<5,true, true>(seed);
+    auto state = Havannah::State<5, true, true>(seed);
     doTest(state);
     std::cout << "test pass: havannah5pieExt" << std::endl;
   }
 
   {
     std::cout << "testing: havannah8pieExt" << std::endl;
-    auto state = Havannah::State<8,true, true>(seed);
+    auto state = Havannah::State<8, true, true>(seed);
     doTest(state);
     std::cout << "test pass: havannah8pieExt" << std::endl;
   }
 
   {
     std::cout << "testing: havannah5pie" << std::endl;
-    auto state = Havannah::State<5,true, false>(seed);
+    auto state = Havannah::State<5, true, false>(seed);
     doTest(state);
     std::cout << "test pass: havannah5pie" << std::endl;
   }
 
   {
     std::cout << "testing: havannah8pie" << std::endl;
-    auto state = Havannah::State<8,true, false>(seed);
+    auto state = Havannah::State<8, true, false>(seed);
     doTest(state);
     std::cout << "test pass: havannah8pie" << std::endl;
   }
 
   {
     std::cout << "testing: havannah5" << std::endl;
-    auto state = Havannah::State<5,false, false>(seed);
+    auto state = Havannah::State<5, false, false>(seed);
     doTest(state);
     std::cout << "test pass: havannah5" << std::endl;
   }
 
   {
     std::cout << "testing: havannah8" << std::endl;
-    auto state = Havannah::State<8,false, false>(seed);
+    auto state = Havannah::State<8, false, false>(seed);
     doTest(state);
     std::cout << "test pass: havannah8" << std::endl;
   }

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -1,4 +1,5 @@
-// inspired from https://gist.github.com/alexminnaar/90cf1ea3de45e79a1b14081d90d214b7
+// inspired from
+// https://gist.github.com/alexminnaar/90cf1ea3de45e79a1b14081d90d214b7
 
 /*
 Copyright (c) 2020 Alex Minnaar
@@ -23,8 +24,8 @@ SOFTWARE.
 
 #include <cstring>
 #include <iostream>
-#include <string>
 #include <stdio.h>
+#include <string>
 
 namespace Ludii {
 
@@ -32,71 +33,76 @@ JavaVM* JNIUtils::jvm = nullptr;
 JNIEnv* JNIUtils::env = nullptr;
 jint JNIUtils::res = 0;
 
-JNIEnv *JNIUtils::GetEnv() { return env; }
+JNIEnv* JNIUtils::GetEnv() {
+  return env;
+}
 
 void JNIUtils::InitJVM(std::string jar_location) {
-	if (env != nullptr)
-		return;		// We've already initialised the JVM
+  if (env != nullptr)
+    return;  // We've already initialised the JVM
 
-	std::cout << "intializing JVM" << std::endl;
-	if (jar_location.empty()) jar_location = "ludii/Ludii.jar";
-	
-	// Check if we can actually access the JAR file
-	if (FILE* file = fopen(jar_location.c_str(), "rb")) {
-		// The Ludii.jar file seems to be there, so we're fine!
-		fclose(file);
-	}
-	else {
-		// Can't find the Ludii.jar file
-		return;
-	}
-	
+  std::cout << "intializing JVM" << std::endl;
+  if (jar_location.empty())
+    jar_location = "ludii/Ludii.jar";
+
+  // Check if we can actually access the JAR file
+  if (FILE* file = fopen(jar_location.c_str(), "rb")) {
+    // The Ludii.jar file seems to be there, so we're fine!
+    fclose(file);
+  } else {
+    // Can't find the Ludii.jar file
+    return;
+  }
+
 #ifdef JNI_VERSION_1_2
-	JavaVMInitArgs vm_args;
-	JavaVMOption options[1];
-	std::string java_classpath = "-Djava.class.path=" + jar_location;
-	char *c_classpath = strdup(java_classpath.c_str());
-	options[0].optionString = c_classpath;
-	vm_args.version = 0x00010002;
-	vm_args.options = options;
-	vm_args.nOptions = 1;
-	vm_args.ignoreUnrecognized = JNI_TRUE;
-	/* Create the Java VM */
-	res = JNI_CreateJavaVM(&jvm, (void **)&env, &vm_args);
-	free(c_classpath);
+  JavaVMInitArgs vm_args;
+  JavaVMOption options[1];
+  std::string java_classpath = "-Djava.class.path=" + jar_location;
+  char* c_classpath = strdup(java_classpath.c_str());
+  options[0].optionString = c_classpath;
+  vm_args.version = 0x00010002;
+  vm_args.options = options;
+  vm_args.nOptions = 1;
+  vm_args.ignoreUnrecognized = JNI_TRUE;
+  /* Create the Java VM */
+  res = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
+  free(c_classpath);
 #else
-	JDK1_1InitArgs vm_args;
-	std::string classpath = vm_args.classpath + ";" + jar_location;
-	char* c_classpath = strdup(java_classpath.c_str());
-	vm_args.version = 0x00010001;
-	JNI_GetDefaultJavaVMInitArgs(&vm_args);
-	/* Append jar location to the default system class path */
-	vm_args.classpath = c_classpath;
-	/* Create the Java VM */
-	res = JNI_CreateJavaVM(&jvm, &env, &vm_args);
-	free(c_classpath);
+  JDK1_1InitArgs vm_args;
+  std::string classpath = vm_args.classpath + ";" + jar_location;
+  char* c_classpath = strdup(java_classpath.c_str());
+  vm_args.version = 0x00010001;
+  JNI_GetDefaultJavaVMInitArgs(&vm_args);
+  /* Append jar location to the default system class path */
+  vm_args.classpath = c_classpath;
+  /* Create the Java VM */
+  res = JNI_CreateJavaVM(&jvm, &env, &vm_args);
+  free(c_classpath);
 #endif /* JNI_VERSION_1_2 */
 
-	// Find our LudiiGameWrapper Java class
-	ludiiGameWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("utils/LudiiGameWrapper"));
+  // Find our LudiiGameWrapper Java class
+  ludiiGameWrapperClass =
+      (jclass)env->NewGlobalRef(env->FindClass("utils/LudiiGameWrapper"));
 
-	// Find our LudiiStateWrapper Java class
-	ludiiStateWrapperClass = (jclass) env->NewGlobalRef(env->FindClass("utils/LudiiStateWrapper"));
+  // Find our LudiiStateWrapper Java class
+  ludiiStateWrapperClass =
+      (jclass)env->NewGlobalRef(env->FindClass("utils/LudiiStateWrapper"));
 
-	// Find the method ID for the static method giving us the Ludii versio
-	ludiiVersionMethodID = env->GetStaticMethodID(ludiiGameWrapperClass, "ludiiVersion", "()Ljava/lang/String;");
+  // Find the method ID for the static method giving us the Ludii versio
+  ludiiVersionMethodID = env->GetStaticMethodID(
+      ludiiGameWrapperClass, "ludiiVersion", "()Ljava/lang/String;");
 
-	std::cout << "Using Ludii version " << LudiiVersion() << std::endl;
+  std::cout << "Using Ludii version " << LudiiVersion() << std::endl;
 }
 
 void JNIUtils::CloseJVM() {
-	env->DeleteGlobalRef(ludiiStateWrapperClass);
-	env->DeleteGlobalRef(ludiiGameWrapperClass);
-	jvm->DestroyJavaVM();
+  env->DeleteGlobalRef(ludiiStateWrapperClass);
+  env->DeleteGlobalRef(ludiiGameWrapperClass);
+  jvm->DestroyJavaVM();
 
-	jvm = nullptr;
-	env = nullptr;
-	res = 0;
+  jvm = nullptr;
+  env = nullptr;
+  res = 0;
 }
 
 // These will be assigned proper values by InitJVM() call
@@ -105,19 +111,20 @@ jclass JNIUtils::ludiiStateWrapperClass = nullptr;
 jmethodID JNIUtils::ludiiVersionMethodID = nullptr;
 
 jclass JNIUtils::LudiiGameWrapperClass() {
-	return ludiiGameWrapperClass;
+  return ludiiGameWrapperClass;
 }
 
 jclass JNIUtils::LudiiStateWrapperClass() {
-	return ludiiStateWrapperClass;
+  return ludiiStateWrapperClass;
 }
 
 const std::string JNIUtils::LudiiVersion() {
-	jstring jstr = (jstring) (env->CallStaticObjectMethod(ludiiGameWrapperClass, ludiiVersionMethodID));
-	const char* strReturn = env->GetStringUTFChars(jstr, (jboolean*) 0);
-	const std::string str = strReturn;
-	env->ReleaseStringUTFChars(jstr, strReturn);
-	return str;
+  jstring jstr = (jstring)(
+      env->CallStaticObjectMethod(ludiiGameWrapperClass, ludiiVersionMethodID));
+  const char* strReturn = env->GetStringUTFChars(jstr, (jboolean*)0);
+  const std::string str = strReturn;
+  env->ReleaseStringUTFChars(jstr, strReturn);
+  return str;
 }
 
 }  // namespace Ludii

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -24,6 +24,7 @@ SOFTWARE.
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <stdio.h>
 
 namespace Ludii {
 
@@ -39,6 +40,17 @@ void JNIUtils::InitJVM(std::string jar_location) {
 
 	std::cout << "intializing JVM" << std::endl;
 	if (jar_location.empty()) jar_location = "ludii/Ludii.jar";
+	
+	// Check if we can actually access the JAR file
+	if (FILE* file = fopen(name.c_str(), "rb")) {
+		// The Ludii.jar file seems to be there, so we're fine!
+		fclose(file);
+	}
+	else {
+		// Can't find the Ludii.jar file
+		return;
+	}
+	
 #ifdef JNI_VERSION_1_2
 	JavaVMInitArgs vm_args;
 	JavaVMOption options[1];

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -42,7 +42,7 @@ void JNIUtils::InitJVM(std::string jar_location) {
 	if (jar_location.empty()) jar_location = "ludii/Ludii.jar";
 	
 	// Check if we can actually access the JAR file
-	if (FILE* file = fopen(name.c_str(), "rb")) {
+	if (FILE* file = fopen(jar_location.c_str(), "rb")) {
 		// The Ludii.jar file seems to be there, so we're fine!
 		fclose(file);
 	}


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

It used to be that if we ran `./build/test_state` without having the `/ludii/Ludii.jar` file present, the test would fail because it also tests some of the Ludii integration. Since the Ludii integration should really just be an "optional" part of Polygames, we should allow the test to run and just skip the Ludii parts if the Ludii.jar file is not installed. That's what this code does :) See issue #45 .

Note: I also modified the `.circleci/config.yml` file such that it skips CI builds on the `dennis-tests` branch which I'm using to play around and test little things. Since the builds seem to take a really long time now, and sometimes fail anyway, I prefer this since it lets me more freely push frequently without having to worry about clogging up CI with many long builds or receiving many angry emails about failing builds. I make sure to test locally before sending PRs, and CircleCI should still run on PRs like this anyway :)

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

Removed my `Ludii.jar` file, ran `./build/test_state`, and it ran without failing as we want.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
