### PR TITLE
[DO NOT MERGE] recycle ludii game wrappers

### DIFF
--- a/core/game.h
+++ b/core/game.h
@@ -235,9 +235,17 @@ to look into this) if the strategy is identical to knuth’s.
       JNIEnv* jni_env = Ludii::JNIUtils::GetEnv();
 
       if (jni_env) {
-        Ludii::LudiiGameWrapper game_wrapper(jni_env, ludii_name);
-        state_ = std::make_unique<Ludii::LudiiStateWrapper>(
-            seed, jni_env, std::move(game_wrapper));
+        if (ludii_name == Ludii::LudiiGameWrapper::last_ludii_game_name) {
+          // We can recycle previously-constructed Java object
+          state_ = std::make_unique<Ludii::LudiiStateWrapper>(
+              seed, jni_env,
+              std::move(Ludii::LudiiGameWrapper::last_ludii_game_wrapper));
+        } else {
+          // We need to instantiate a new Java object
+          Ludii::LudiiGameWrapper game_wrapper(jni_env, ludii_name);
+          state_ = std::make_unique<Ludii::LudiiStateWrapper>(
+              seed, jni_env, std::move(game_wrapper));
+        }
       } else {
         // Probably means we couldn't find the Ludii.jar file
         throw std::runtime_error(

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -16,6 +16,9 @@
 
 namespace Ludii {
 
+LudiiGameWrapper LudiiGameWrapper::last_ludii_game_wrapper;
+std::string LudiiGameWrapper::last_ludii_game_name = "";
+
 // NOTE: String descriptions of signatures of Java methods can be found by
 // navigating to directory containing the .class files and using:
 //
@@ -50,6 +53,10 @@ LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv, const std::string lud_path)
 
   // Clean up memory
   jenv->DeleteLocalRef(java_lud_path);
+
+  // Cache recycleable LudiiGameWrapper object
+  last_ludii_game_wrapper = *this;
+  last_ludii_game_name = lud_path;
 }
 
 LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv,
@@ -97,6 +104,8 @@ LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv,
   jenv->DeleteLocalRef(java_lud_path);
   jenv->DeleteLocalRef(java_game_options);  // TODO see if we also need to clean
                                             // elements of array first?
+
+  // TODO also handle the Game object caching with options
 }
 
 LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other)
@@ -110,6 +119,21 @@ LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other)
   stateTensorsShapeMethodID = other.stateTensorsShapeMethodID;
   moveTensorsShapeMethodID = other.moveTensorsShapeMethodID;
   stateTensorChannelNamesMethodID = other.stateTensorChannelNamesMethodID;
+}
+
+LudiiGameWrapper& LudiiGameWrapper::operator=(LudiiGameWrapper const& other) {
+  jenv = other.jenv;
+
+  // We can just copy the pointer to the same Java Game object
+  ludiiGameWrapperJavaObject =
+      jenv->NewGlobalRef(other.ludiiGameWrapperJavaObject);
+
+  // We can just copy all the pointers to methods
+  stateTensorsShapeMethodID = other.stateTensorsShapeMethodID;
+  moveTensorsShapeMethodID = other.moveTensorsShapeMethodID;
+  stateTensorChannelNamesMethodID = other.stateTensorChannelNamesMethodID;
+
+  return *this;
 }
 
 LudiiGameWrapper::~LudiiGameWrapper() {

--- a/games/ludii/ludii_game_wrapper.h
+++ b/games/ludii/ludii_game_wrapper.h
@@ -53,12 +53,14 @@ class LudiiGameWrapper {
                    const std::vector<std::string> game_options);
 
   /**
-   * Copy constructor; calls the Java copy constructor for LudiiGameWrapper
-   *
-   * @param other The LudiiGameWrapper object of which we wish to create a deep
-   * copy
+   * Copy constructor. Re-uses the same Java LudiiGameWrapper object.
    */
   LudiiGameWrapper(LudiiGameWrapper const&);
+
+  /**
+   * Copy-assignment operator. Re-uses the same Java LudiiGameWrapper object.
+   */
+  LudiiGameWrapper& operator=(LudiiGameWrapper const& other);
 
   /**
    * Destructor
@@ -86,12 +88,27 @@ class LudiiGameWrapper {
   /** Our object of Java's LudiiGameWrapper type */
   jobject ludiiGameWrapperJavaObject;
 
- private:
-  // We don't want to be accidentally coyping objects of this class
-  // (without having implemented our own, correct copy constructor or assignment
-  // operator)
-  LudiiGameWrapper& operator=(LudiiGameWrapper const&) = delete;
+  /** The last LudiiGameWrapper object we've instantiated */
+  static LudiiGameWrapper last_ludii_game_wrapper;
 
+  /** The Ludii game name of the last Ludii game we've instantiated */
+  static std::string last_ludii_game_name;
+
+  /**
+   * Zero-args constructor which initializes everything to invalid data
+   * (only used to initialize the static member for recycling LudiiGameWrapper
+   * objects)
+   */
+  LudiiGameWrapper()
+      : jenv(nullptr)
+      , stateTensorsShapeMethodID(nullptr)
+      , moveTensorsShapeMethodID(nullptr)
+      , stateTensorChannelNamesMethodID(nullptr)
+      , stateTensorsShape(nullptr)
+      , moveTensorsShape(nullptr) {
+  }
+
+ private:
   /** Pointer to the JNI environment, allows for communication with Ludii's Java
    * code */
   JNIEnv* jenv;


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The Ludii parts of the code remembers which Ludii game was last constructed, and recycles the last constructed LudiiGameWrapper object from Java if it's the same one that we want to instantiate again. 

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

On the Java side, these objects are fairly big and can in some cases take a while to construct, but they're also immutable and can safely be re-used by multiple different episodes (even simultaneously from different threads). So it's better to frequently use the same object instead of instantiating many different new Java objects.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
