### PR TITLE
Improve jni memory

### DIFF
--- a/core/game.h
+++ b/core/game.h
@@ -235,9 +235,17 @@ to look into this) if the strategy is identical to knuth’s.
       JNIEnv* jni_env = Ludii::JNIUtils::GetEnv();
 
       if (jni_env) {
-        Ludii::LudiiGameWrapper game_wrapper(jni_env, ludii_name);
-        state_ = std::make_unique<Ludii::LudiiStateWrapper>(
-            seed, jni_env, std::move(game_wrapper));
+        if (ludii_name == Ludii::LudiiGameWrapper::last_ludii_game_name) {
+          // We can recycle previously-constructed Java object
+          state_ = std::make_unique<Ludii::LudiiStateWrapper>(
+              seed, jni_env,
+              std::move(Ludii::LudiiGameWrapper::last_ludii_game_wrapper));
+        } else {
+          // We need to instantiate a new Java object
+          Ludii::LudiiGameWrapper game_wrapper(jni_env, ludii_name);
+          state_ = std::make_unique<Ludii::LudiiStateWrapper>(
+              seed, jni_env, std::move(game_wrapper));
+        }
       } else {
         // Probably means we couldn't find the Ludii.jar file
         throw std::runtime_error(

--- a/core/game.h
+++ b/core/game.h
@@ -235,17 +235,9 @@ to look into this) if the strategy is identical to knuth’s.
       JNIEnv* jni_env = Ludii::JNIUtils::GetEnv();
 
       if (jni_env) {
-        if (ludii_name == Ludii::LudiiGameWrapper::last_ludii_game_name) {
-          // We can recycle previously-constructed Java object
-          state_ = std::make_unique<Ludii::LudiiStateWrapper>(
-              seed,
-              std::move(Ludii::LudiiGameWrapper::last_ludii_game_wrapper));
-        } else {
-          // We need to instantiate a new Java object
-          Ludii::LudiiGameWrapper game_wrapper(ludii_name);
-          state_ = std::make_unique<Ludii::LudiiStateWrapper>(
-              seed, std::move(game_wrapper));
-        }
+        Ludii::LudiiGameWrapper game_wrapper(ludii_name);
+        state_ = std::make_unique<Ludii::LudiiStateWrapper>(
+            seed, std::move(game_wrapper));
       } else {
         // Probably means we couldn't find the Ludii.jar file
         throw std::runtime_error(

--- a/core/game.h
+++ b/core/game.h
@@ -238,7 +238,7 @@ to look into this) if the strategy is identical to knuth’s.
         if (ludii_name == Ludii::LudiiGameWrapper::last_ludii_game_name) {
           // We can recycle previously-constructed Java object
           state_ = std::make_unique<Ludii::LudiiStateWrapper>(
-              seed, jni_env,
+              seed,
               std::move(Ludii::LudiiGameWrapper::last_ludii_game_wrapper));
         } else {
           // We need to instantiate a new Java object

--- a/core/game.h
+++ b/core/game.h
@@ -244,7 +244,7 @@ to look into this) if the strategy is identical to knuth’s.
           // We need to instantiate a new Java object
           Ludii::LudiiGameWrapper game_wrapper(jni_env, ludii_name);
           state_ = std::make_unique<Ludii::LudiiStateWrapper>(
-              seed, jni_env, std::move(game_wrapper));
+              seed, std::move(game_wrapper));
         }
       } else {
         // Probably means we couldn't find the Ludii.jar file

--- a/core/game.h
+++ b/core/game.h
@@ -242,7 +242,7 @@ to look into this) if the strategy is identical to knuth’s.
               std::move(Ludii::LudiiGameWrapper::last_ludii_game_wrapper));
         } else {
           // We need to instantiate a new Java object
-          Ludii::LudiiGameWrapper game_wrapper(jni_env, ludii_name);
+          Ludii::LudiiGameWrapper game_wrapper(ludii_name);
           state_ = std::make_unique<Ludii::LudiiStateWrapper>(
               seed, std::move(game_wrapper));
         }

--- a/core/test_state.cc
+++ b/core/test_state.cc
@@ -152,7 +152,7 @@ int main() {
     JNIEnv* jni_env = Ludii::JNIUtils::GetEnv();
 
     if (jni_env) {
-      Ludii::LudiiGameWrapper game_wrapper(jni_env, "Tic-Tac-Toe.lud");
+      Ludii::LudiiGameWrapper game_wrapper("Tic-Tac-Toe.lud");
       auto state = std::make_unique<Ludii::LudiiStateWrapper>(
           seed, std::move(game_wrapper));
       doTest(*state);

--- a/core/test_state.cc
+++ b/core/test_state.cc
@@ -154,7 +154,7 @@ int main() {
     if (jni_env) {
       Ludii::LudiiGameWrapper game_wrapper(jni_env, "Tic-Tac-Toe.lud");
       auto state = std::make_unique<Ludii::LudiiStateWrapper>(
-          seed, jni_env, std::move(game_wrapper));
+          seed, std::move(game_wrapper));
       doTest(*state);
       Ludii::JNIUtils::CloseJVM();
       std::cout << "test pass: Ludii Tic-Tac-Toe" << std::endl;

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -162,6 +162,8 @@ const std::string JNIUtils::LudiiVersion() {
   const std::string str = strReturn;
   env->ReleaseStringUTFChars(jstr, strReturn);
   CHECK_JNI_EXCEPTION(env);
+  env->DeleteLocalRef(jstr);
+  CHECK_JNI_EXCEPTION(env);
   return str;
 }
 

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -53,29 +53,29 @@ void JNIUtils::InitJVM(std::string jar_location) {
     // Can't find the Ludii.jar file
     return;
   }
-  
-//#define CHECK_JNI  // Uncomment this to run extra checks for JNI
+
+  //#define CHECK_JNI  // Uncomment this to run extra checks for JNI
 
 #ifdef JNI_VERSION_1_2
   JavaVMInitArgs vm_args;
-  
+
 #ifdef CHECK_JNI
   const size_t num_jvm_args = 2;
 #else
   const size_t num_jvm_args = 1;
 #endif
-  
+
   JavaVMOption options[num_jvm_args];
   std::string java_classpath = "-Djava.class.path=" + jar_location;
   char* c_classpath = strdup(java_classpath.c_str());
   options[0].optionString = c_classpath;
-  
+
 #ifdef CHECK_JNI
   std::string checK_jni = "-Xcheck:jni";
   char* c_check_jni = strdup(check_jni.c_str());
   options[1].optionString = c_check_jni;
 #endif
-  
+
   vm_args.version = 0x00010002;
   vm_args.options = options;
   vm_args.nOptions = num_jvm_args;
@@ -83,11 +83,11 @@ void JNIUtils::InitJVM(std::string jar_location) {
   /* Create the Java VM */
   res = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
   free(c_classpath);
-  
+
 #ifdef CHECK_JNI
   free(c_check_jni);
 #endif
-  
+
 #else
   JDK1_1InitArgs vm_args;
   std::string classpath = vm_args.classpath + ";" + jar_location;
@@ -104,14 +104,17 @@ void JNIUtils::InitJVM(std::string jar_location) {
   // Find our LudiiGameWrapper Java class
   ludiiGameWrapperClass =
       (jclass)env->NewGlobalRef(env->FindClass("utils/LudiiGameWrapper"));
+  CHECK_JNI_EXCEPTION(env);
 
   // Find our LudiiStateWrapper Java class
   ludiiStateWrapperClass =
       (jclass)env->NewGlobalRef(env->FindClass("utils/LudiiStateWrapper"));
+  CHECK_JNI_EXCEPTION(env);
 
   // Find the method ID for the static method giving us the Ludii versio
   ludiiVersionMethodID = env->GetStaticMethodID(
       ludiiGameWrapperClass, "ludiiVersion", "()Ljava/lang/String;");
+  CHECK_JNI_EXCEPTION(env);
 
   std::cout << "Using Ludii version " << LudiiVersion() << std::endl;
 }
@@ -142,9 +145,12 @@ jclass JNIUtils::LudiiStateWrapperClass() {
 const std::string JNIUtils::LudiiVersion() {
   jstring jstr = (jstring)(
       env->CallStaticObjectMethod(ludiiGameWrapperClass, ludiiVersionMethodID));
+  CHECK_JNI_EXCEPTION(env);
   const char* strReturn = env->GetStringUTFChars(jstr, (jboolean*)0);
+  CHECK_JNI_EXCEPTION(env);
   const std::string str = strReturn;
   env->ReleaseStringUTFChars(jstr, strReturn);
+  CHECK_JNI_EXCEPTION(env);
   return str;
 }
 

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -53,20 +53,41 @@ void JNIUtils::InitJVM(std::string jar_location) {
     // Can't find the Ludii.jar file
     return;
   }
+  
+//#define CHECK_JNI  // Uncomment this to run extra checks for JNI
 
 #ifdef JNI_VERSION_1_2
   JavaVMInitArgs vm_args;
-  JavaVMOption options[1];
+  
+#ifdef CHECK_JNI
+  const size_t num_jvm_args = 2;
+#else
+  const size_t num_jvm_args = 1;
+#endif
+  
+  JavaVMOption options[num_jvm_args];
   std::string java_classpath = "-Djava.class.path=" + jar_location;
   char* c_classpath = strdup(java_classpath.c_str());
   options[0].optionString = c_classpath;
+  
+#ifdef CHECK_JNI
+  std::string checK_jni = "-Xcheck:jni";
+  char* c_check_jni = strdup(check_jni.c_str());
+  options[1].optionString = c_check_jni;
+#endif
+  
   vm_args.version = 0x00010002;
   vm_args.options = options;
-  vm_args.nOptions = 1;
+  vm_args.nOptions = num_jvm_args;
   vm_args.ignoreUnrecognized = JNI_TRUE;
   /* Create the Java VM */
   res = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
   free(c_classpath);
+  
+#ifdef CHECK_JNI
+  free(c_check_jni);
+#endif
+  
 #else
   JDK1_1InitArgs vm_args;
   std::string classpath = vm_args.classpath + ";" + jar_location;

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -71,7 +71,7 @@ void JNIUtils::InitJVM(std::string jar_location) {
   options[0].optionString = c_classpath;
 
 #ifdef CHECK_JNI
-  std::string checK_jni = "-Xcheck:jni";
+  std::string check_jni = "-Xcheck:jni";
   char* c_check_jni = strdup(check_jni.c_str());
   options[1].optionString = c_check_jni;
 #endif

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -114,17 +114,17 @@ void JNIUtils::InitJVM(std::string jar_location) {
   // Find our LudiiGameWrapper Java class
   ludiiGameWrapperClass =
       (jclass)env->NewGlobalRef(env->FindClass("utils/LudiiGameWrapper"));
-  CHECK_JNI_EXCEPTION(env);
+  CheckJniException(env);
 
   // Find our LudiiStateWrapper Java class
   ludiiStateWrapperClass =
       (jclass)env->NewGlobalRef(env->FindClass("utils/LudiiStateWrapper"));
-  CHECK_JNI_EXCEPTION(env);
+  CheckJniException(env);
 
   // Find the method ID for the static method giving us the Ludii versio
   ludiiVersionMethodID = env->GetStaticMethodID(
       ludiiGameWrapperClass, "ludiiVersion", "()Ljava/lang/String;");
-  CHECK_JNI_EXCEPTION(env);
+  CheckJniException(env);
 
   std::cout << "Using Ludii version " << LudiiVersion() << std::endl;
 }
@@ -159,14 +159,14 @@ const std::string JNIUtils::LudiiVersion() {
   JNIEnv* env = JNIUtils::GetEnv();
   jstring jstr = (jstring)(
       env->CallStaticObjectMethod(ludiiGameWrapperClass, ludiiVersionMethodID));
-  CHECK_JNI_EXCEPTION(env);
+  CheckJniException(env);
   const char* strReturn = env->GetStringUTFChars(jstr, (jboolean*)0);
-  CHECK_JNI_EXCEPTION(env);
+  CheckJniException(env);
   const std::string str = strReturn;
   env->ReleaseStringUTFChars(jstr, strReturn);
-  CHECK_JNI_EXCEPTION(env);
+  CheckJniException(env);
   env->DeleteLocalRef(jstr);
-  CHECK_JNI_EXCEPTION(env);
+  CheckJniException(env);
   return str;
 }
 

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -32,13 +32,16 @@ namespace Ludii {
 JavaVM* JNIUtils::jvm = nullptr;
 jint JNIUtils::res = 0;
 
+thread_local JNIEnv* JNIUtils::env = nullptr;
+
 JNIEnv* JNIUtils::GetEnv() {
   if (jvm == nullptr)
     return nullptr;
 
-  JavaVMAttachArgs args = {JNI_VERSION_1_2, 0, 0};
-  JNIEnv* env;
-  jvm->AttachCurrentThread((void**)&env, &args);
+  if (env == nullptr) {
+    JavaVMAttachArgs args = {JNI_VERSION_1_2, 0, 0};
+    jvm->AttachCurrentThread((void**)&env, &args);
+  }
 
   return env;
 }

--- a/games/ludii/jni_utils.cc
+++ b/games/ludii/jni_utils.cc
@@ -77,13 +77,11 @@ void JNIUtils::InitJVM(std::string jar_location) {
 
   JavaVMOption options[num_jvm_args];
   std::string java_classpath = "-Djava.class.path=" + jar_location;
-  char* c_classpath = strdup(java_classpath.c_str());
-  options[0].optionString = c_classpath;
+  options[0].optionString = java_classpath.data();
 
 #ifdef CHECK_JNI
   std::string check_jni = "-Xcheck:jni";
-  char* c_check_jni = strdup(check_jni.c_str());
-  options[1].optionString = c_check_jni;
+  options[1].optionString = check_jni.data();
 #endif
 
   vm_args.version = 0x00010002;
@@ -92,23 +90,15 @@ void JNIUtils::InitJVM(std::string jar_location) {
   vm_args.ignoreUnrecognized = JNI_TRUE;
   /* Create the Java VM */
   res = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
-  free(c_classpath);
-
-#ifdef CHECK_JNI
-  free(c_check_jni);
-#endif
-
 #else
   JDK1_1InitArgs vm_args;
   std::string classpath = vm_args.classpath + ";" + jar_location;
-  char* c_classpath = strdup(java_classpath.c_str());
   vm_args.version = 0x00010001;
   JNI_GetDefaultJavaVMInitArgs(&vm_args);
   /* Append jar location to the default system class path */
-  vm_args.classpath = c_classpath;
+  vm_args.classpath = java_classpath.data();
   /* Create the Java VM */
   res = JNI_CreateJavaVM(&jvm, &env, &vm_args);
-  free(c_classpath);
 #endif /* JNI_VERSION_1_2 */
 
   // Find our LudiiGameWrapper Java class

--- a/games/ludii/jni_utils.h
+++ b/games/ludii/jni_utils.h
@@ -60,6 +60,8 @@ class JNIUtils {
  private:
   static JavaVM* jvm;
   static jint res;
+  
+  thread_local static JNIEnv* env;
 
   /** Our LudiiGameWrapper class in Java */
   static jclass ludiiGameWrapperClass;

--- a/games/ludii/jni_utils.h
+++ b/games/ludii/jni_utils.h
@@ -59,7 +59,6 @@ class JNIUtils {
 
  private:
   static JavaVM* jvm;
-  static JNIEnv* env;
   static jint res;
 
   /** Our LudiiGameWrapper class in Java */

--- a/games/ludii/jni_utils.h
+++ b/games/ludii/jni_utils.h
@@ -26,9 +26,9 @@ SOFTWARE.
 #pragma once
 
 #include <cstring>
-#include <string>
-#include <stdexcept>
 #include <jni.h>  // NOLINT
+#include <stdexcept>
+#include <string>
 
 namespace Ludii {
 
@@ -38,13 +38,13 @@ class JNIUtils {
 
   static void InitJVM(std::string jar_location);
   static void CloseJVM();
-  
+
   static void CheckJniException(JNIEnv* jenv) {
     if (jenv->ExceptionCheck()) {
-	  jenv->ExceptionDescribe();
-	  jenv->ExceptionClear();
-	  throw std::runtime_error("Java exception thrown!");
-	}
+      jenv->ExceptionDescribe();
+      jenv->ExceptionClear();
+      throw std::runtime_error("Java exception thrown!");
+    }
   }
 
   static jclass LudiiGameWrapperClass();

--- a/games/ludii/jni_utils.h
+++ b/games/ludii/jni_utils.h
@@ -60,7 +60,7 @@ class JNIUtils {
  private:
   static JavaVM* jvm;
   static jint res;
-  
+
   thread_local static JNIEnv* env;
 
   /** Our LudiiGameWrapper class in Java */

--- a/games/ludii/jni_utils.h
+++ b/games/ludii/jni_utils.h
@@ -1,8 +1,8 @@
-// strongly inspired from https://gist.github.com/alexminnaar/90cf1ea3de45e79a1b14081d90d214b7
-// might need something like export LD_LIBRARY_PATH=/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/
-// maybe also install jvm
-
-
+// strongly inspired from
+// https://gist.github.com/alexminnaar/90cf1ea3de45e79a1b14081d90d214b7 might
+// need something like export
+// LD_LIBRARY_PATH=/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/ maybe
+// also install jvm
 
 /*
 Copyright (c) 2020 Alex Minnaar
@@ -30,11 +30,20 @@ SOFTWARE.
 
 #include <jni.h>  // NOLINT
 
+// TODO maybe we should optimise these checks out when
+// we're doing serious training runs/evaluations, since
+// we don't handle them other than printing them anyway?
+#define CHECK_JNI_EXCEPTION(jenv)                                              \
+  if (jenv->ExceptionCheck()) {                                                \
+    jenv->ExceptionDescribe();                                                 \
+    jni->ExceptionClear();                                                     \
+  }
+
 namespace Ludii {
 
 class JNIUtils {
  public:
-  static JNIEnv *GetEnv();
+  static JNIEnv* GetEnv();
 
   static void InitJVM(std::string jar_location);
   static void CloseJVM();
@@ -43,13 +52,14 @@ class JNIUtils {
   static jclass LudiiStateWrapperClass();
 
   /**
-   * @return A string description of the version of Ludii that we're working with.
+   * @return A string description of the version of Ludii that we're working
+   * with.
    */
   static const std::string LudiiVersion();
 
  private:
-  static JavaVM *jvm;
-  static JNIEnv *env;
+  static JavaVM* jvm;
+  static JNIEnv* env;
   static jint res;
 
   /** Our LudiiGameWrapper class in Java */
@@ -63,5 +73,3 @@ class JNIUtils {
 };
 
 }  // namespace Ludii
-
-

--- a/games/ludii/jni_utils.h
+++ b/games/ludii/jni_utils.h
@@ -27,17 +27,8 @@ SOFTWARE.
 
 #include <cstring>
 #include <string>
-
+#include <stdexcept>
 #include <jni.h>  // NOLINT
-
-// TODO maybe we should optimise these checks out when
-// we're doing serious training runs/evaluations, since
-// we don't handle them other than printing them anyway?
-#define CHECK_JNI_EXCEPTION(jenv)                                              \
-  if (jenv->ExceptionCheck()) {                                                \
-    jenv->ExceptionDescribe();                                                 \
-    jenv->ExceptionClear();                                                    \
-  }
 
 namespace Ludii {
 
@@ -47,6 +38,14 @@ class JNIUtils {
 
   static void InitJVM(std::string jar_location);
   static void CloseJVM();
+  
+  static void CheckJniException(JNIEnv* jenv) {
+    if (jenv->ExceptionCheck()) {
+	  jenv->ExceptionDescribe();
+	  jenv->ExceptionClear();
+	  throw std::runtime_error("Java exception thrown!");
+	}
+  }
 
   static jclass LudiiGameWrapperClass();
   static jclass LudiiStateWrapperClass();

--- a/games/ludii/jni_utils.h
+++ b/games/ludii/jni_utils.h
@@ -36,7 +36,7 @@ SOFTWARE.
 #define CHECK_JNI_EXCEPTION(jenv)                                              \
   if (jenv->ExceptionCheck()) {                                                \
     jenv->ExceptionDescribe();                                                 \
-    jni->ExceptionClear();                                                     \
+    jenv->ExceptionClear();                                                    \
   }
 
 namespace Ludii {

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -38,9 +38,11 @@ LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path)
   CHECK_JNI_EXCEPTION(jenv);
 
   // Call our Java constructor to instantiate new object
-  ludiiGameWrapperJavaObject = jenv->NewGlobalRef(jenv->NewObject(
-      ludiiGameWrapperClass, ludiiGameWrapperConstructor, java_lud_path));
+  jobject local_ref = jenv->NewObject(
+      ludiiGameWrapperClass, ludiiGameWrapperConstructor, java_lud_path);
   CHECK_JNI_EXCEPTION(jenv);
+  ludiiGameWrapperJavaObject = jenv->NewGlobalRef(local_ref);
+  jenv->DeleteLocalRef(local_ref);
 
   // Find method IDs for the two tensor shape Java methods that we may be
   // calling frequently
@@ -94,10 +96,12 @@ LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path,
   }
 
   // Call our Java constructor to instantiate new object
-  ludiiGameWrapperJavaObject = jenv->NewGlobalRef(
+  jobject local_ref =
       jenv->NewObject(ludiiGameWrapperClass, ludiiGameWrapperConstructor,
-                      java_lud_path, java_game_options));
+                      java_lud_path, java_game_options);
   CHECK_JNI_EXCEPTION(jenv);
+  ludiiGameWrapperJavaObject = jenv->NewGlobalRef(local_ref);
+  jenv->DeleteLocalRef(local_ref);
 
   // Find method IDs for the two tensor shape Java methods that we may be
   // calling frequently

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -25,7 +25,7 @@ std::string LudiiGameWrapper::last_ludii_game_name = "";
 // javap -s <ClassName.class>
 
 LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path) {
-	
+
   JNIEnv* jenv = JNIUtils::GetEnv();
   jclass ludiiGameWrapperClass = JNIUtils::LudiiGameWrapperClass();
 
@@ -69,8 +69,8 @@ LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path) {
   last_ludii_game_name = lud_path;
 }
 
-LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path,
-                                   const std::vector<std::string> game_options)  {
+LudiiGameWrapper::LudiiGameWrapper(
+    const std::string lud_path, const std::vector<std::string> game_options) {
 
   JNIEnv* jenv = JNIUtils::GetEnv();
   jclass ludiiGameWrapperClass = JNIUtils::LudiiGameWrapperClass();
@@ -167,8 +167,8 @@ LudiiGameWrapper::~LudiiGameWrapper() {
 
 const std::array<int, 3>& LudiiGameWrapper::StateTensorsShape() {
   if (not stateTensorsShape) {
-	JNIEnv* jenv = JNIUtils::GetEnv();
-	  
+    JNIEnv* jenv = JNIUtils::GetEnv();
+
     // Get our array of Java ints
     const jintArray jint_array = static_cast<jintArray>(jenv->CallObjectMethod(
         ludiiGameWrapperJavaObject, stateTensorsShapeMethodID));
@@ -190,8 +190,8 @@ const std::array<int, 3>& LudiiGameWrapper::StateTensorsShape() {
 
 const std::array<int, 3>& LudiiGameWrapper::MoveTensorsShape() {
   if (not moveTensorsShape) {
-	JNIEnv* jenv = JNIUtils::GetEnv();
-	  
+    JNIEnv* jenv = JNIUtils::GetEnv();
+
     // Get our array of Java ints
     const jintArray jint_array = static_cast<jintArray>(jenv->CallObjectMethod(
         ludiiGameWrapperJavaObject, moveTensorsShapeMethodID));

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -24,8 +24,8 @@ std::string LudiiGameWrapper::last_ludii_game_name = "";
 //
 // javap -s <ClassName.class>
 
-LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv, const std::string lud_path)
-    : jenv(jenv) {
+LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path)
+    : jenv(JNIUtils::GetEnv()) {
   jclass ludiiGameWrapperClass = JNIUtils::LudiiGameWrapperClass();
 
   // Find the LudiiGameWrapper Java constructor
@@ -66,10 +66,9 @@ LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv, const std::string lud_path)
   last_ludii_game_name = lud_path;
 }
 
-LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv,
-                                   const std::string lud_path,
+LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path,
                                    const std::vector<std::string> game_options)
-    : jenv(jenv) {
+    : jenv(JNIUtils::GetEnv()) {
 
   jclass ludiiGameWrapperClass = JNIUtils::LudiiGameWrapperClass();
 
@@ -124,7 +123,7 @@ LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv,
 }
 
 LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other)
-    : jenv(other.jenv) {
+    : jenv(JNIUtils::GetEnv()) {
 
   // We can just copy the pointer to the same Java Game object
   ludiiGameWrapperJavaObject =
@@ -138,7 +137,7 @@ LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other)
 }
 
 LudiiGameWrapper& LudiiGameWrapper::operator=(LudiiGameWrapper const& other) {
-  jenv = other.jenv;
+  jenv = JNIUtils::GetEnv();
 
   // We can just copy the pointer to the same Java Game object
   ludiiGameWrapperJavaObject =

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -24,8 +24,9 @@ std::string LudiiGameWrapper::last_ludii_game_name = "";
 //
 // javap -s <ClassName.class>
 
-LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path)
-    : jenv(JNIUtils::GetEnv()) {
+LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path) {
+	
+  JNIEnv* jenv = JNIUtils::GetEnv();
   jclass ludiiGameWrapperClass = JNIUtils::LudiiGameWrapperClass();
 
   // Find the LudiiGameWrapper Java constructor
@@ -69,9 +70,9 @@ LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path)
 }
 
 LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path,
-                                   const std::vector<std::string> game_options)
-    : jenv(JNIUtils::GetEnv()) {
+                                   const std::vector<std::string> game_options)  {
 
+  JNIEnv* jenv = JNIUtils::GetEnv();
   jclass ludiiGameWrapperClass = JNIUtils::LudiiGameWrapperClass();
 
   // Find the LudiiGameWrapper Java constructor (with extra argument for
@@ -126,8 +127,9 @@ LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path,
   // TODO also handle the Game object caching with options
 }
 
-LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other)
-    : jenv(JNIUtils::GetEnv()) {
+LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other) {
+
+  JNIEnv* jenv = JNIUtils::GetEnv();
 
   // We can just copy the pointer to the same Java Game object
   ludiiGameWrapperJavaObject =
@@ -141,7 +143,7 @@ LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other)
 }
 
 LudiiGameWrapper& LudiiGameWrapper::operator=(LudiiGameWrapper const& other) {
-  jenv = JNIUtils::GetEnv();
+  JNIEnv* jenv = JNIUtils::GetEnv();
 
   // We can just copy the pointer to the same Java Game object
   ludiiGameWrapperJavaObject =
@@ -157,15 +159,16 @@ LudiiGameWrapper& LudiiGameWrapper::operator=(LudiiGameWrapper const& other) {
 }
 
 LudiiGameWrapper::~LudiiGameWrapper() {
-  // Don't use jenv directly because it may have been deleted
-  JNIEnv* env = Ludii::JNIUtils::GetEnv();
-  if (env) {
+  JNIEnv* jenv = JNIUtils::GetEnv();
+  if (jenv) {
     jenv->DeleteGlobalRef(ludiiGameWrapperJavaObject);
   }
 }
 
 const std::array<int, 3>& LudiiGameWrapper::StateTensorsShape() {
   if (not stateTensorsShape) {
+	JNIEnv* jenv = JNIUtils::GetEnv();
+	  
     // Get our array of Java ints
     const jintArray jint_array = static_cast<jintArray>(jenv->CallObjectMethod(
         ludiiGameWrapperJavaObject, stateTensorsShapeMethodID));
@@ -187,6 +190,8 @@ const std::array<int, 3>& LudiiGameWrapper::StateTensorsShape() {
 
 const std::array<int, 3>& LudiiGameWrapper::MoveTensorsShape() {
   if (not moveTensorsShape) {
+	JNIEnv* jenv = JNIUtils::GetEnv();
+	  
     // Get our array of Java ints
     const jintArray jint_array = static_cast<jintArray>(jenv->CallObjectMethod(
         ludiiGameWrapperJavaObject, moveTensorsShapeMethodID));
@@ -207,6 +212,7 @@ const std::array<int, 3>& LudiiGameWrapper::MoveTensorsShape() {
 }
 
 const std::vector<std::string> LudiiGameWrapper::stateTensorChannelNames() {
+  JNIEnv* jenv = JNIUtils::GetEnv();
   std::vector<std::string> channelNames;
 
   const jobjectArray java_arr =

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -31,28 +31,35 @@ LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv, const std::string lud_path)
   // Find the LudiiGameWrapper Java constructor
   jmethodID ludiiGameWrapperConstructor = jenv->GetMethodID(
       ludiiGameWrapperClass, "<init>", "(Ljava/lang/String;)V");
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Convert our lud path into a Java string
   jstring java_lud_path = jenv->NewStringUTF(lud_path.c_str());
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Call our Java constructor to instantiate new object
   ludiiGameWrapperJavaObject = jenv->NewGlobalRef(jenv->NewObject(
       ludiiGameWrapperClass, ludiiGameWrapperConstructor, java_lud_path));
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Find method IDs for the two tensor shape Java methods that we may be
   // calling frequently
   stateTensorsShapeMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "stateTensorsShape", "()[I");
+  CHECK_JNI_EXCEPTION(jenv);
   moveTensorsShapeMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "moveTensorsShape", "()[I");
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Find the method ID for the stateTensorChannelNames() method in Java
   stateTensorChannelNamesMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "stateTensorChannelNames",
                         "()[Ljava/lang/String;");
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Clean up memory
   jenv->DeleteLocalRef(java_lud_path);
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Cache recycleable LudiiGameWrapper object
   last_ludii_game_wrapper = *this;
@@ -71,34 +78,42 @@ LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv,
   jmethodID ludiiGameWrapperConstructor =
       jenv->GetMethodID(ludiiGameWrapperClass, "<init>",
                         "(Ljava/lang/String;[Ljava/lang/String;)V");
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Convert our lud path into a Java string
   jstring java_lud_path = jenv->NewStringUTF(lud_path.c_str());
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Convert vector of game options into array of Java strings
   const jobjectArray java_game_options = (jobjectArray)jenv->NewObjectArray(
       game_options.size(), jenv->FindClass("java/lang/String"), nullptr);
+  CHECK_JNI_EXCEPTION(jenv);
   for (size_t i = 0; i < game_options.size(); ++i) {
     jenv->SetObjectArrayElement(
         java_game_options, i, jenv->NewStringUTF(game_options[i].c_str()));
+    CHECK_JNI_EXCEPTION(jenv);
   }
 
   // Call our Java constructor to instantiate new object
   ludiiGameWrapperJavaObject = jenv->NewGlobalRef(
       jenv->NewObject(ludiiGameWrapperClass, ludiiGameWrapperConstructor,
                       java_lud_path, java_game_options));
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Find method IDs for the two tensor shape Java methods that we may be
   // calling frequently
   stateTensorsShapeMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "stateTensorsShape", "()[I");
+  CHECK_JNI_EXCEPTION(jenv);
   moveTensorsShapeMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "moveTensorsShape", "()[I");
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Find the method ID for the stateTensorChannelNames() method in Java
   stateTensorChannelNamesMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "stateTensorChannelNames",
                         "()[Ljava/lang/String;");
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Clean up memory
   jenv->DeleteLocalRef(java_lud_path);
@@ -114,6 +129,7 @@ LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other)
   // We can just copy the pointer to the same Java Game object
   ludiiGameWrapperJavaObject =
       jenv->NewGlobalRef(other.ludiiGameWrapperJavaObject);
+  CHECK_JNI_EXCEPTION(jenv);
 
   // We can just copy all the pointers to methods
   stateTensorsShapeMethodID = other.stateTensorsShapeMethodID;
@@ -127,6 +143,7 @@ LudiiGameWrapper& LudiiGameWrapper::operator=(LudiiGameWrapper const& other) {
   // We can just copy the pointer to the same Java Game object
   ludiiGameWrapperJavaObject =
       jenv->NewGlobalRef(other.ludiiGameWrapperJavaObject);
+  CHECK_JNI_EXCEPTION(jenv);
 
   // We can just copy all the pointers to methods
   stateTensorsShapeMethodID = other.stateTensorsShapeMethodID;
@@ -149,7 +166,9 @@ const std::array<int, 3>& LudiiGameWrapper::StateTensorsShape() {
     // Get our array of Java ints
     const jintArray jint_array = static_cast<jintArray>(jenv->CallObjectMethod(
         ludiiGameWrapperJavaObject, stateTensorsShapeMethodID));
+    CHECK_JNI_EXCEPTION(jenv);
     jint* jints = jenv->GetIntArrayElements(jint_array, nullptr);
+    CHECK_JNI_EXCEPTION(jenv);
 
     // Create our C++ array of 3 ints
     stateTensorsShape = std::make_unique<std::array<int, 3>>(
@@ -167,7 +186,9 @@ const std::array<int, 3>& LudiiGameWrapper::MoveTensorsShape() {
     // Get our array of Java ints
     const jintArray jint_array = static_cast<jintArray>(jenv->CallObjectMethod(
         ludiiGameWrapperJavaObject, moveTensorsShapeMethodID));
+    CHECK_JNI_EXCEPTION(jenv);
     jint* jints = jenv->GetIntArrayElements(jint_array, nullptr);
+    CHECK_JNI_EXCEPTION(jenv);
 
     // Create our C++ array of 3 ints
     moveTensorsShape = std::make_unique<std::array<int, 3>>(
@@ -186,14 +207,19 @@ const std::vector<std::string> LudiiGameWrapper::stateTensorChannelNames() {
   const jobjectArray java_arr =
       static_cast<jobjectArray>(jenv->CallObjectMethod(
           ludiiGameWrapperJavaObject, stateTensorChannelNamesMethodID));
+  CHECK_JNI_EXCEPTION(jenv);
   const int len = jenv->GetArrayLength(java_arr);
+  CHECK_JNI_EXCEPTION(jenv);
 
   for (int i = 0; i < len; ++i) {
     jstring jstr = (jstring)(jenv->GetObjectArrayElement(java_arr, i));
+    CHECK_JNI_EXCEPTION(jenv);
 
     // Convert Java string to C++ string
     const jsize jstr_len = jenv->GetStringUTFLength(jstr);
+    CHECK_JNI_EXCEPTION(jenv);
     const char* chars = jenv->GetStringUTFChars(jstr, (jboolean*)0);
+    CHECK_JNI_EXCEPTION(jenv);
     std::string str(chars, jstr_len);
 
     channelNames.push_back(str);

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -32,16 +32,16 @@ LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path) {
   // Find the LudiiGameWrapper Java constructor
   jmethodID ludiiGameWrapperConstructor = jenv->GetMethodID(
       ludiiGameWrapperClass, "<init>", "(Ljava/lang/String;)V");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Convert our lud path into a Java string
   jstring java_lud_path = jenv->NewStringUTF(lud_path.c_str());
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Call our Java constructor to instantiate new object
   jobject local_ref = jenv->NewObject(
       ludiiGameWrapperClass, ludiiGameWrapperConstructor, java_lud_path);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   ludiiGameWrapperJavaObject = jenv->NewGlobalRef(local_ref);
   jenv->DeleteLocalRef(local_ref);
 
@@ -49,20 +49,20 @@ LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path) {
   // calling frequently
   stateTensorsShapeMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "stateTensorsShape", "()[I");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   moveTensorsShapeMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "moveTensorsShape", "()[I");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Find the method ID for the stateTensorChannelNames() method in Java
   stateTensorChannelNamesMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "stateTensorChannelNames",
                         "()[Ljava/lang/String;");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Clean up memory
   jenv->DeleteLocalRef(java_lud_path);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Cache recycleable LudiiGameWrapper object
   last_ludii_game_wrapper = *this;
@@ -80,27 +80,27 @@ LudiiGameWrapper::LudiiGameWrapper(
   jmethodID ludiiGameWrapperConstructor =
       jenv->GetMethodID(ludiiGameWrapperClass, "<init>",
                         "(Ljava/lang/String;[Ljava/lang/String;)V");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Convert our lud path into a Java string
   jstring java_lud_path = jenv->NewStringUTF(lud_path.c_str());
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Convert vector of game options into array of Java strings
   const jobjectArray java_game_options = (jobjectArray)jenv->NewObjectArray(
       game_options.size(), jenv->FindClass("java/lang/String"), nullptr);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   for (size_t i = 0; i < game_options.size(); ++i) {
     jenv->SetObjectArrayElement(
         java_game_options, i, jenv->NewStringUTF(game_options[i].c_str()));
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
   }
 
   // Call our Java constructor to instantiate new object
   jobject local_ref =
       jenv->NewObject(ludiiGameWrapperClass, ludiiGameWrapperConstructor,
                       java_lud_path, java_game_options);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   ludiiGameWrapperJavaObject = jenv->NewGlobalRef(local_ref);
   jenv->DeleteLocalRef(local_ref);
 
@@ -108,16 +108,16 @@ LudiiGameWrapper::LudiiGameWrapper(
   // calling frequently
   stateTensorsShapeMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "stateTensorsShape", "()[I");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   moveTensorsShapeMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "moveTensorsShape", "()[I");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Find the method ID for the stateTensorChannelNames() method in Java
   stateTensorChannelNamesMethodID =
       jenv->GetMethodID(ludiiGameWrapperClass, "stateTensorChannelNames",
                         "()[Ljava/lang/String;");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Clean up memory
   jenv->DeleteLocalRef(java_lud_path);
@@ -134,7 +134,7 @@ LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other) {
   // We can just copy the pointer to the same Java Game object
   ludiiGameWrapperJavaObject =
       jenv->NewGlobalRef(other.ludiiGameWrapperJavaObject);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // We can just copy all the pointers to methods
   stateTensorsShapeMethodID = other.stateTensorsShapeMethodID;
@@ -148,7 +148,7 @@ LudiiGameWrapper& LudiiGameWrapper::operator=(LudiiGameWrapper const& other) {
   // We can just copy the pointer to the same Java Game object
   ludiiGameWrapperJavaObject =
       jenv->NewGlobalRef(other.ludiiGameWrapperJavaObject);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // We can just copy all the pointers to methods
   stateTensorsShapeMethodID = other.stateTensorsShapeMethodID;
@@ -172,9 +172,9 @@ const std::array<int, 3>& LudiiGameWrapper::StateTensorsShape() {
     // Get our array of Java ints
     const jintArray jint_array = static_cast<jintArray>(jenv->CallObjectMethod(
         ludiiGameWrapperJavaObject, stateTensorsShapeMethodID));
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
     jint* jints = jenv->GetIntArrayElements(jint_array, nullptr);
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
 
     // Create our C++ array of 3 ints
     stateTensorsShape = std::make_unique<std::array<int, 3>>(
@@ -195,9 +195,9 @@ const std::array<int, 3>& LudiiGameWrapper::MoveTensorsShape() {
     // Get our array of Java ints
     const jintArray jint_array = static_cast<jintArray>(jenv->CallObjectMethod(
         ludiiGameWrapperJavaObject, moveTensorsShapeMethodID));
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
     jint* jints = jenv->GetIntArrayElements(jint_array, nullptr);
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
 
     // Create our C++ array of 3 ints
     moveTensorsShape = std::make_unique<std::array<int, 3>>(
@@ -218,19 +218,19 @@ const std::vector<std::string> LudiiGameWrapper::stateTensorChannelNames() {
   const jobjectArray java_arr =
       static_cast<jobjectArray>(jenv->CallObjectMethod(
           ludiiGameWrapperJavaObject, stateTensorChannelNamesMethodID));
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   const int len = jenv->GetArrayLength(java_arr);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   for (int i = 0; i < len; ++i) {
     jstring jstr = (jstring)(jenv->GetObjectArrayElement(java_arr, i));
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
 
     // Convert Java string to C++ string
     const jsize jstr_len = jenv->GetStringUTFLength(jstr);
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
     const char* chars = jenv->GetStringUTFChars(jstr, (jboolean*)0);
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
     std::string str(chars, jstr_len);
 
     channelNames.push_back(str);

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -16,6 +16,9 @@
 
 namespace Ludii {
 
+LudiiGameWrapper LudiiGameWrapper::last_ludii_game_wrapper;
+std::string LudiiGameWrapper::last_ludii_game_name = "";
+
 // NOTE: String descriptions of signatures of Java methods can be found by
 // navigating to directory containing the .class files and using:
 //
@@ -50,6 +53,10 @@ LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv, const std::string lud_path)
 
   // Clean up memory
   jenv->DeleteLocalRef(java_lud_path);
+
+  // Cache recycleable LudiiGameWrapper object
+  last_ludii_game_wrapper = *this;
+  last_ludii_game_name = lud_path;
 }
 
 LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv,
@@ -97,6 +104,8 @@ LudiiGameWrapper::LudiiGameWrapper(JNIEnv* jenv,
   jenv->DeleteLocalRef(java_lud_path);
   jenv->DeleteLocalRef(java_game_options);  // TODO see if we also need to clean
                                             // elements of array first?
+
+  // TODO also handle the Game object caching with options
 }
 
 LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other)
@@ -110,6 +119,21 @@ LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other)
   stateTensorsShapeMethodID = other.stateTensorsShapeMethodID;
   moveTensorsShapeMethodID = other.moveTensorsShapeMethodID;
   stateTensorChannelNamesMethodID = other.stateTensorChannelNamesMethodID;
+}
+
+LudiiGameWrapper& LudiiGameWrapper::operator=(LudiiGameWrapper const& other) {
+  jenv = other.jenv;
+
+  // We can just copy the pointer to the same Java Game object
+  ludiiGameWrapperJavaObject =
+      jenv->NewGlobalRef(other.ludiiGameWrapperJavaObject);
+
+  // We can just copy all the pointers to methods
+  stateTensorsShapeMethodID = other.stateTensorsShapeMethodID;
+  moveTensorsShapeMethodID = other.moveTensorsShapeMethodID;
+  stateTensorChannelNamesMethodID = other.stateTensorChannelNamesMethodID;
+
+  return *this;
 }
 
 LudiiGameWrapper::~LudiiGameWrapper() {

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -16,9 +16,6 @@
 
 namespace Ludii {
 
-LudiiGameWrapper LudiiGameWrapper::last_ludii_game_wrapper;
-std::string LudiiGameWrapper::last_ludii_game_name = "";
-
 // NOTE: String descriptions of signatures of Java methods can be found by
 // navigating to directory containing the .class files and using:
 //
@@ -63,10 +60,6 @@ LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path) {
   // Clean up memory
   jenv->DeleteLocalRef(java_lud_path);
   JNIUtils::CheckJniException(jenv);
-
-  // Cache recycleable LudiiGameWrapper object
-  last_ludii_game_wrapper = *this;
-  last_ludii_game_name = lud_path;
 }
 
 LudiiGameWrapper::LudiiGameWrapper(

--- a/games/ludii/ludii_game_wrapper.cc
+++ b/games/ludii/ludii_game_wrapper.cc
@@ -176,6 +176,7 @@ const std::array<int, 3>& LudiiGameWrapper::StateTensorsShape() {
 
     // Allow JVM to clean up memory now that we have our own ints
     jenv->ReleaseIntArrayElements(jint_array, jints, 0);
+    jenv->DeleteLocalRef(jint_array);
   }
 
   return *stateTensorsShape;
@@ -196,6 +197,7 @@ const std::array<int, 3>& LudiiGameWrapper::MoveTensorsShape() {
 
     // Allow JVM to clean up memory now that we have our own ints
     jenv->ReleaseIntArrayElements(jint_array, jints, 0);
+    jenv->DeleteLocalRef(jint_array);
   }
 
   return *moveTensorsShape;

--- a/games/ludii/ludii_game_wrapper.h
+++ b/games/ludii/ludii_game_wrapper.h
@@ -85,25 +85,6 @@ class LudiiGameWrapper {
   /** Our object of Java's LudiiGameWrapper type */
   jobject ludiiGameWrapperJavaObject;
 
-  /** The last LudiiGameWrapper object we've instantiated */
-  static LudiiGameWrapper last_ludii_game_wrapper;
-
-  /** The Ludii game name of the last Ludii game we've instantiated */
-  static std::string last_ludii_game_name;
-
-  /**
-   * Zero-args constructor which initializes everything to invalid data
-   * (only used to initialize the static member for recycling LudiiGameWrapper
-   * objects)
-   */
-  LudiiGameWrapper()
-      : stateTensorsShapeMethodID(nullptr)
-      , moveTensorsShapeMethodID(nullptr)
-      , stateTensorChannelNamesMethodID(nullptr)
-      , stateTensorsShape(nullptr)
-      , moveTensorsShape(nullptr) {
-  }
-
  private:
   /** Method ID for the stateTensorsShape() method in Java */
   jmethodID stateTensorsShapeMethodID;

--- a/games/ludii/ludii_game_wrapper.h
+++ b/games/ludii/ludii_game_wrapper.h
@@ -33,23 +33,20 @@ class LudiiGameWrapper {
   /**
    * Constructor; calls the LudiiGameWrapper Java constructor
    *
-   * @param jenv Our JNI environment
    * @param lud_path String describing the path of the game to load. Should end
    * in .lud
    */
-  LudiiGameWrapper(JNIEnv* jenv, const std::string lud_path);
+  LudiiGameWrapper(const std::string lud_path);
 
   /**
    * Constructor; calls the LudiiGameWrapper Java constructor
    *
-   * @param jenv Our JNI environment
    * @param lud_path String describing the path of the game to load. Should end
    * in .lud
    * @param game_options Vector of additiona options to pass into Ludii,
    * describing variant of game to load.
    */
-  LudiiGameWrapper(JNIEnv* jenv,
-                   const std::string lud_path,
+  LudiiGameWrapper(const std::string lud_path,
                    const std::vector<std::string> game_options);
 
   /**

--- a/games/ludii/ludii_game_wrapper.h
+++ b/games/ludii/ludii_game_wrapper.h
@@ -53,12 +53,14 @@ class LudiiGameWrapper {
                    const std::vector<std::string> game_options);
 
   /**
-   * Copy constructor; calls the Java copy constructor for LudiiGameWrapper
-   *
-   * @param other The LudiiGameWrapper object of which we wish to create a deep
-   * copy
+   * Copy constructor. Re-uses the same Java LudiiGameWrapper object.
    */
   LudiiGameWrapper(LudiiGameWrapper const&);
+
+  /**
+   * Copy-assignment operator. Re-uses the same Java LudiiGameWrapper object.
+   */
+  LudiiGameWrapper& operator=(LudiiGameWrapper const& other);
 
   /**
    * Destructor
@@ -86,12 +88,27 @@ class LudiiGameWrapper {
   /** Our object of Java's LudiiGameWrapper type */
   jobject ludiiGameWrapperJavaObject;
 
- private:
-  // We don't want to be accidentally coyping objects of this class
-  // (without having implemented our own, correct copy constructor or assignment
-  // operator)
-  LudiiGameWrapper& operator=(LudiiGameWrapper const&) = delete;
+  /** The last LudiiGameWrapper object we've instantiated */
+  static LudiiGameWrapper last_ludii_game_wrapper;
 
+  /** The Ludii game name of the last Ludii game we've instantiated */
+  static std::string last_ludii_game_name;
+
+  /**
+   * Zero-args constructor which initializes everything to invalid data
+   * (only used to initialize the static member for recycling LudiiGameWrapper
+   * objects)
+   */
+  LudiiGameWrapper()
+      : jenv(nullptr)
+      , stateTensorsShapeMethodID(nullptr)
+      , moveTensorsShapeMethodID(nullptr)
+      , stateTensorChannelNamesMethodID(nullptr)
+      , stateTensorsShape(nullptr)
+      , moveTensorsShape(nullptr) {
+  }
+
+ private:
   /** Pointer to the JNI environment, allows for communication with Ludii's Java
    * code */
   JNIEnv* jenv;

--- a/games/ludii/ludii_game_wrapper.h
+++ b/games/ludii/ludii_game_wrapper.h
@@ -97,8 +97,7 @@ class LudiiGameWrapper {
    * objects)
    */
   LudiiGameWrapper()
-      : jenv(nullptr)
-      , stateTensorsShapeMethodID(nullptr)
+      : stateTensorsShapeMethodID(nullptr)
       , moveTensorsShapeMethodID(nullptr)
       , stateTensorChannelNamesMethodID(nullptr)
       , stateTensorsShape(nullptr)
@@ -106,10 +105,6 @@ class LudiiGameWrapper {
   }
 
  private:
-  /** Pointer to the JNI environment, allows for communication with Ludii's Java
-   * code */
-  JNIEnv* jenv;
-
   /** Method ID for the stateTensorsShape() method in Java */
   jmethodID stateTensorsShapeMethodID;
 

--- a/games/ludii/ludii_state_wrapper.cc
+++ b/games/ludii/ludii_state_wrapper.cc
@@ -156,28 +156,38 @@ LudiiStateWrapper::LudiiStateWrapper(int seed,
   // Find the LudiiStateWrapper Java constructor
   jmethodID ludiiStateWrapperConstructor = jenv->GetMethodID(
       ludiiStateWrapperClass, "<init>", "(Lutils/LudiiGameWrapper;)V");
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Call our Java constructor to instantiate new object
   ludiiStateWrapperJavaObject = jenv->NewGlobalRef(
       jenv->NewObject(ludiiStateWrapperClass, ludiiStateWrapperConstructor,
                       ludiiGameWrapper->ludiiGameWrapperJavaObject));
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Find method IDs for all the Java methods we may want to call
   legalMovesTensorsMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "legalMovesTensors", "()[[I");
+  CHECK_JNI_EXCEPTION(jenv);
   numLegalMovesMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "numLegalMoves", "()I");
+  CHECK_JNI_EXCEPTION(jenv);
   applyNthMoveMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "applyNthMove", "(I)V");
+  CHECK_JNI_EXCEPTION(jenv);
   returnsMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "returns", "(I)D");
+  CHECK_JNI_EXCEPTION(jenv);
   isTerminalMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "isTerminal", "()Z");
+  CHECK_JNI_EXCEPTION(jenv);
   toTensorMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "toTensor", "()[[[F");
+  CHECK_JNI_EXCEPTION(jenv);
   currentPlayerMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "currentPlayer", "()I");
+  CHECK_JNI_EXCEPTION(jenv);
   resetMethodID = jenv->GetMethodID(ludiiStateWrapperClass, "reset", "()V");
+  CHECK_JNI_EXCEPTION(jenv);
 }
 
 LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
@@ -190,11 +200,13 @@ LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
   // Find the LudiiStateWrapper Java copy constructor
   jmethodID ludiiStateWrapperCopyConstructor = jenv->GetMethodID(
       ludiiStateWrapperClass, "<init>", "(Lutils/LudiiStateWrapper;)V");
+  CHECK_JNI_EXCEPTION(jenv);
 
   // Call our Java constructor to instantiate new object
   ludiiStateWrapperJavaObject = jenv->NewGlobalRef(
       jenv->NewObject(ludiiStateWrapperClass, ludiiStateWrapperCopyConstructor,
                       other.ludiiStateWrapperJavaObject));
+  CHECK_JNI_EXCEPTION(jenv);
 
   // We can just copy all the pointers to methods
   legalMovesTensorsMethodID = other.legalMovesTensorsMethodID;
@@ -219,13 +231,17 @@ std::vector<std::array<int, 3>> LudiiStateWrapper::LegalMovesTensors() const {
   const jobjectArray javaArrOuter =
       static_cast<jobjectArray>(jenv->CallObjectMethod(
           ludiiStateWrapperJavaObject, legalMovesTensorsMethodID));
+  CHECK_JNI_EXCEPTION(jenv);
   const jsize numLegalMoves = jenv->GetArrayLength(javaArrOuter);
+  CHECK_JNI_EXCEPTION(jenv);
 
   std::vector<std::array<int, 3>> matrix(numLegalMoves);
   for (jsize i = 0; i < numLegalMoves; ++i) {
     const jintArray inner =
         static_cast<jintArray>(jenv->GetObjectArrayElement(javaArrOuter, i));
+    CHECK_JNI_EXCEPTION(jenv);
     jint* jints = jenv->GetIntArrayElements(inner, nullptr);
+    CHECK_JNI_EXCEPTION(jenv);
 
     matrix[i] = {jints[0], jints[1], jints[2]};
 
@@ -239,51 +255,68 @@ std::vector<std::array<int, 3>> LudiiStateWrapper::LegalMovesTensors() const {
 }
 
 int LudiiStateWrapper::NumLegalMoves() const {
-  return (int)jenv->CallIntMethod(
+  const int num_legal_moves = (int)jenv->CallIntMethod(
       ludiiStateWrapperJavaObject, numLegalMovesMethodID);
+  CHECK_JNI_EXCEPTION(jenv);
+  return num_legal_moves;
 }
 
 void LudiiStateWrapper::ApplyNthMove(const int n) const {
   jenv->CallVoidMethod(ludiiStateWrapperJavaObject, applyNthMoveMethodID, n);
+  CHECK_JNI_EXCEPTION(jenv);
 }
 
 double LudiiStateWrapper::Returns(const int player) const {
-  return (double)jenv->CallDoubleMethod(
+  const double returns = (double)jenv->CallDoubleMethod(
       ludiiStateWrapperJavaObject, returnsMethodID, player);
+  CHECK_JNI_EXCEPTION(jenv);
+  return returns;
 }
 
 bool LudiiStateWrapper::IsTerminal() const {
-  return (bool)jenv->CallBooleanMethod(
+  const bool is_terminal = (bool)jenv->CallBooleanMethod(
       ludiiStateWrapperJavaObject, isTerminalMethodID);
+  CHECK_JNI_EXCEPTION(jenv);
+  return is_terminal;
 }
 
 int LudiiStateWrapper::CurrentPlayer() const {
-  return (int)jenv->CallIntMethod(
+  const int current_player = (int)jenv->CallIntMethod(
       ludiiStateWrapperJavaObject, currentPlayerMethodID);
+  CHECK_JNI_EXCEPTION(jenv);
+  return current_player;
 }
 
 void LudiiStateWrapper::Reset() const {
   jenv->CallVoidMethod(ludiiStateWrapperJavaObject, resetMethodID);
+  CHECK_JNI_EXCEPTION(jenv);
 }
 
 std::vector<std::vector<std::vector<float>>> LudiiStateWrapper::ToTensor()
     const {
   const jobjectArray channelsArray = static_cast<jobjectArray>(
       jenv->CallObjectMethod(ludiiStateWrapperJavaObject, toTensorMethodID));
+  CHECK_JNI_EXCEPTION(jenv);
   const jsize numChannels = jenv->GetArrayLength(channelsArray);
+  CHECK_JNI_EXCEPTION(jenv);
 
   std::vector<std::vector<std::vector<float>>> tensor(numChannels);
   for (jsize c = 0; c < numChannels; ++c) {
     const jobjectArray xArray = static_cast<jobjectArray>(
         jenv->GetObjectArrayElement(channelsArray, c));
+    CHECK_JNI_EXCEPTION(jenv);
     const jsize numXCoords = jenv->GetArrayLength(xArray);
+    CHECK_JNI_EXCEPTION(jenv);
 
     tensor[c].resize(numXCoords);
     for (jsize x = 0; x < numXCoords; ++x) {
       const jfloatArray yArray =
           static_cast<jfloatArray>(jenv->GetObjectArrayElement(xArray, x));
+      CHECK_JNI_EXCEPTION(jenv);
       const jsize numYCoords = jenv->GetArrayLength(yArray);
+      CHECK_JNI_EXCEPTION(jenv);
       jfloat* jfloats = jenv->GetFloatArrayElements(yArray, nullptr);
+      CHECK_JNI_EXCEPTION(jenv);
 
       tensor[c][x].resize(numYCoords);
       std::copy(jfloats, jfloats + numYCoords, tensor[c][x].begin());

--- a/games/ludii/ludii_state_wrapper.cc
+++ b/games/ludii/ludii_state_wrapper.cc
@@ -247,6 +247,7 @@ std::vector<std::array<int, 3>> LudiiStateWrapper::LegalMovesTensors() const {
 
     // Allow JVM to clean up memory now that we have our own ints
     jenv->ReleaseIntArrayElements(inner, jints, 0);
+    jenv->DeleteLocalRef(inner);
   }
 
   jenv->DeleteLocalRef(javaArrOuter);
@@ -323,6 +324,7 @@ std::vector<std::vector<std::vector<float>>> LudiiStateWrapper::ToTensor()
 
       // Allow JVM to clean up memory now that we have our own ints
       jenv->ReleaseFloatArrayElements(yArray, jfloats, 0);
+      jenv->DeleteLocalRef(yArray);
     }
 
     jenv->DeleteLocalRef(xArray);

--- a/games/ludii/ludii_state_wrapper.cc
+++ b/games/ludii/ludii_state_wrapper.cc
@@ -134,40 +134,40 @@ LudiiStateWrapper::LudiiStateWrapper(int seed,
   // Find the LudiiStateWrapper Java constructor
   jmethodID ludiiStateWrapperConstructor = jenv->GetMethodID(
       ludiiStateWrapperClass, "<init>", "(Lutils/LudiiGameWrapper;)V");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Call our Java constructor to instantiate new object
   jobject local_ref =
       jenv->NewObject(ludiiStateWrapperClass, ludiiStateWrapperConstructor,
                       ludiiGameWrapper->ludiiGameWrapperJavaObject);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   ludiiStateWrapperJavaObject = jenv->NewGlobalRef(local_ref);
   jenv->DeleteLocalRef(local_ref);
 
   // Find method IDs for all the Java methods we may want to call
   legalMovesTensorsMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "legalMovesTensors", "()[[I");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   numLegalMovesMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "numLegalMoves", "()I");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   applyNthMoveMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "applyNthMove", "(I)V");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   returnsMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "returns", "(I)D");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   isTerminalMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "isTerminal", "()Z");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   toTensorMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "toTensor", "()[[[F");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   currentPlayerMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "currentPlayer", "()I");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   resetMethodID = jenv->GetMethodID(ludiiStateWrapperClass, "reset", "()V");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 }
 
 LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
@@ -180,13 +180,13 @@ LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
   // Find the LudiiStateWrapper Java copy constructor
   jmethodID ludiiStateWrapperCopyConstructor = jenv->GetMethodID(
       ludiiStateWrapperClass, "<init>", "(Lutils/LudiiStateWrapper;)V");
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   // Call our Java constructor to instantiate new object
   jobject local_ref =
       jenv->NewObject(ludiiStateWrapperClass, ludiiStateWrapperCopyConstructor,
                       other.ludiiStateWrapperJavaObject);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   ludiiStateWrapperJavaObject = jenv->NewGlobalRef(local_ref);
   jenv->DeleteLocalRef(local_ref);
 
@@ -213,17 +213,17 @@ std::vector<std::array<int, 3>> LudiiStateWrapper::LegalMovesTensors() const {
   const jobjectArray javaArrOuter =
       static_cast<jobjectArray>(jenv->CallObjectMethod(
           ludiiStateWrapperJavaObject, legalMovesTensorsMethodID));
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   const jsize numLegalMoves = jenv->GetArrayLength(javaArrOuter);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   std::vector<std::array<int, 3>> matrix(numLegalMoves);
   for (jsize i = 0; i < numLegalMoves; ++i) {
     const jintArray inner =
         static_cast<jintArray>(jenv->GetObjectArrayElement(javaArrOuter, i));
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
     jint* jints = jenv->GetIntArrayElements(inner, nullptr);
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
 
     matrix[i] = {jints[0], jints[1], jints[2]};
 
@@ -241,21 +241,21 @@ int LudiiStateWrapper::NumLegalMoves() const {
   JNIEnv* jenv = JNIUtils::GetEnv();
   const int num_legal_moves = (int)jenv->CallIntMethod(
       ludiiStateWrapperJavaObject, numLegalMovesMethodID);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   return num_legal_moves;
 }
 
 void LudiiStateWrapper::ApplyNthMove(const int n) const {
   JNIEnv* jenv = JNIUtils::GetEnv();
   jenv->CallVoidMethod(ludiiStateWrapperJavaObject, applyNthMoveMethodID, n);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 }
 
 double LudiiStateWrapper::Returns(const int player) const {
   JNIEnv* jenv = JNIUtils::GetEnv();
   const double returns = (double)jenv->CallDoubleMethod(
       ludiiStateWrapperJavaObject, returnsMethodID, player);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   return returns;
 }
 
@@ -263,7 +263,7 @@ bool LudiiStateWrapper::IsTerminal() const {
   JNIEnv* jenv = JNIUtils::GetEnv();
   const bool is_terminal = (bool)jenv->CallBooleanMethod(
       ludiiStateWrapperJavaObject, isTerminalMethodID);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   return is_terminal;
 }
 
@@ -271,14 +271,14 @@ int LudiiStateWrapper::CurrentPlayer() const {
   JNIEnv* jenv = JNIUtils::GetEnv();
   const int current_player = (int)jenv->CallIntMethod(
       ludiiStateWrapperJavaObject, currentPlayerMethodID);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   return current_player;
 }
 
 void LudiiStateWrapper::Reset() const {
   JNIEnv* jenv = JNIUtils::GetEnv();
   jenv->CallVoidMethod(ludiiStateWrapperJavaObject, resetMethodID);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 }
 
 std::vector<std::vector<std::vector<float>>> LudiiStateWrapper::ToTensor()
@@ -286,27 +286,27 @@ std::vector<std::vector<std::vector<float>>> LudiiStateWrapper::ToTensor()
   JNIEnv* jenv = JNIUtils::GetEnv();
   const jobjectArray channelsArray = static_cast<jobjectArray>(
       jenv->CallObjectMethod(ludiiStateWrapperJavaObject, toTensorMethodID));
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
   const jsize numChannels = jenv->GetArrayLength(channelsArray);
-  CHECK_JNI_EXCEPTION(jenv);
+  JNIUtils::CheckJniException(jenv);
 
   std::vector<std::vector<std::vector<float>>> tensor(numChannels);
   for (jsize c = 0; c < numChannels; ++c) {
     const jobjectArray xArray = static_cast<jobjectArray>(
         jenv->GetObjectArrayElement(channelsArray, c));
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
     const jsize numXCoords = jenv->GetArrayLength(xArray);
-    CHECK_JNI_EXCEPTION(jenv);
+    JNIUtils::CheckJniException(jenv);
 
     tensor[c].resize(numXCoords);
     for (jsize x = 0; x < numXCoords; ++x) {
       const jfloatArray yArray =
           static_cast<jfloatArray>(jenv->GetObjectArrayElement(xArray, x));
-      CHECK_JNI_EXCEPTION(jenv);
+      JNIUtils::CheckJniException(jenv);
       const jsize numYCoords = jenv->GetArrayLength(yArray);
-      CHECK_JNI_EXCEPTION(jenv);
+      JNIUtils::CheckJniException(jenv);
       jfloat* jfloats = jenv->GetFloatArrayElements(yArray, nullptr);
-      CHECK_JNI_EXCEPTION(jenv);
+      JNIUtils::CheckJniException(jenv);
 
       tensor[c][x].resize(numYCoords);
       std::copy(jfloats, jfloats + numYCoords, tensor[c][x].begin());

--- a/games/ludii/ludii_state_wrapper.cc
+++ b/games/ludii/ludii_state_wrapper.cc
@@ -24,10 +24,6 @@ Action::Action(int i, int j, int k) {
 }
 
 void LudiiStateWrapper::Initialize() {
-  // This is sometimes necessary to ensure correct JEnv for thread
-  jenv = JNIUtils::GetEnv();
-
-  // Now do the normal initialisation
   Reset();
 
   _hash = 0;  // TODO implement hash for stochastic games
@@ -128,9 +124,9 @@ void LudiiStateWrapper::DoGoodAction() {
 
 LudiiStateWrapper::LudiiStateWrapper(int seed,
                                      LudiiGameWrapper&& inLudiiGameWrapper)
-    : ::State(seed)
-    , jenv(JNIUtils::GetEnv()) {
+    : ::State(seed) {
 
+  JNIEnv* jenv = JNIUtils::GetEnv();
   ludiiGameWrapper =
       std::make_shared<LudiiGameWrapper>(std::move(inLudiiGameWrapper));
   jclass ludiiStateWrapperClass = JNIUtils::LudiiStateWrapperClass();
@@ -176,9 +172,9 @@ LudiiStateWrapper::LudiiStateWrapper(int seed,
 
 LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
     : ::State(other)
-    , jenv(JNIUtils::GetEnv())
     , ludiiGameWrapper(other.ludiiGameWrapper) {
 
+  JNIEnv* jenv = JNIUtils::GetEnv();
   jclass ludiiStateWrapperClass = JNIUtils::LudiiStateWrapperClass();
 
   // Find the LudiiStateWrapper Java copy constructor
@@ -206,14 +202,14 @@ LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
 }
 
 LudiiStateWrapper::~LudiiStateWrapper() {
-  // Don't use jenv directly because it may have been deleted
-  JNIEnv* env = Ludii::JNIUtils::GetEnv();
-  if (env) {
+  JNIEnv* jenv = JNIUtils::GetEnv();
+  if (jenv) {
     jenv->DeleteGlobalRef(ludiiStateWrapperJavaObject);
   }
 }
 
 std::vector<std::array<int, 3>> LudiiStateWrapper::LegalMovesTensors() const {
+  JNIEnv* jenv = JNIUtils::GetEnv();
   const jobjectArray javaArrOuter =
       static_cast<jobjectArray>(jenv->CallObjectMethod(
           ludiiStateWrapperJavaObject, legalMovesTensorsMethodID));
@@ -242,6 +238,7 @@ std::vector<std::array<int, 3>> LudiiStateWrapper::LegalMovesTensors() const {
 }
 
 int LudiiStateWrapper::NumLegalMoves() const {
+  JNIEnv* jenv = JNIUtils::GetEnv();
   const int num_legal_moves = (int)jenv->CallIntMethod(
       ludiiStateWrapperJavaObject, numLegalMovesMethodID);
   CHECK_JNI_EXCEPTION(jenv);
@@ -249,11 +246,13 @@ int LudiiStateWrapper::NumLegalMoves() const {
 }
 
 void LudiiStateWrapper::ApplyNthMove(const int n) const {
+  JNIEnv* jenv = JNIUtils::GetEnv();
   jenv->CallVoidMethod(ludiiStateWrapperJavaObject, applyNthMoveMethodID, n);
   CHECK_JNI_EXCEPTION(jenv);
 }
 
 double LudiiStateWrapper::Returns(const int player) const {
+  JNIEnv* jenv = JNIUtils::GetEnv();
   const double returns = (double)jenv->CallDoubleMethod(
       ludiiStateWrapperJavaObject, returnsMethodID, player);
   CHECK_JNI_EXCEPTION(jenv);
@@ -261,6 +260,7 @@ double LudiiStateWrapper::Returns(const int player) const {
 }
 
 bool LudiiStateWrapper::IsTerminal() const {
+  JNIEnv* jenv = JNIUtils::GetEnv();
   const bool is_terminal = (bool)jenv->CallBooleanMethod(
       ludiiStateWrapperJavaObject, isTerminalMethodID);
   CHECK_JNI_EXCEPTION(jenv);
@@ -268,6 +268,7 @@ bool LudiiStateWrapper::IsTerminal() const {
 }
 
 int LudiiStateWrapper::CurrentPlayer() const {
+  JNIEnv* jenv = JNIUtils::GetEnv();
   const int current_player = (int)jenv->CallIntMethod(
       ludiiStateWrapperJavaObject, currentPlayerMethodID);
   CHECK_JNI_EXCEPTION(jenv);
@@ -275,12 +276,14 @@ int LudiiStateWrapper::CurrentPlayer() const {
 }
 
 void LudiiStateWrapper::Reset() const {
+  JNIEnv* jenv = JNIUtils::GetEnv();
   jenv->CallVoidMethod(ludiiStateWrapperJavaObject, resetMethodID);
   CHECK_JNI_EXCEPTION(jenv);
 }
 
 std::vector<std::vector<std::vector<float>>> LudiiStateWrapper::ToTensor()
     const {
+  JNIEnv* jenv = JNIUtils::GetEnv();
   const jobjectArray channelsArray = static_cast<jobjectArray>(
       jenv->CallObjectMethod(ludiiStateWrapperJavaObject, toTensorMethodID));
   CHECK_JNI_EXCEPTION(jenv);

--- a/games/ludii/ludii_state_wrapper.cc
+++ b/games/ludii/ludii_state_wrapper.cc
@@ -24,6 +24,9 @@ Action::Action(int i, int j, int k) {
 }
 
 void LudiiStateWrapper::Initialize() {
+  // This is sometimes necessary to ensure correct JEnv for thread
+  jenv = JNIUtils::GetEnv();
+	
   // Now do the normal initialisation
   Reset();
 

--- a/games/ludii/ludii_state_wrapper.cc
+++ b/games/ludii/ludii_state_wrapper.cc
@@ -26,7 +26,7 @@ Action::Action(int i, int j, int k) {
 void LudiiStateWrapper::Initialize() {
   // This is sometimes necessary to ensure correct JEnv for thread
   jenv = JNIUtils::GetEnv();
-	
+
   // Now do the normal initialisation
   Reset();
 
@@ -141,10 +141,12 @@ LudiiStateWrapper::LudiiStateWrapper(int seed,
   CHECK_JNI_EXCEPTION(jenv);
 
   // Call our Java constructor to instantiate new object
-  ludiiStateWrapperJavaObject = jenv->NewGlobalRef(
+  jobject local_ref =
       jenv->NewObject(ludiiStateWrapperClass, ludiiStateWrapperConstructor,
-                      ludiiGameWrapper->ludiiGameWrapperJavaObject));
+                      ludiiGameWrapper->ludiiGameWrapperJavaObject);
   CHECK_JNI_EXCEPTION(jenv);
+  ludiiStateWrapperJavaObject = jenv->NewGlobalRef(local_ref);
+  jenv->DeleteLocalRef(local_ref);
 
   // Find method IDs for all the Java methods we may want to call
   legalMovesTensorsMethodID =
@@ -185,10 +187,12 @@ LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
   CHECK_JNI_EXCEPTION(jenv);
 
   // Call our Java constructor to instantiate new object
-  ludiiStateWrapperJavaObject = jenv->NewGlobalRef(
+  jobject local_ref =
       jenv->NewObject(ludiiStateWrapperClass, ludiiStateWrapperCopyConstructor,
-                      other.ludiiStateWrapperJavaObject));
+                      other.ludiiStateWrapperJavaObject);
   CHECK_JNI_EXCEPTION(jenv);
+  ludiiStateWrapperJavaObject = jenv->NewGlobalRef(local_ref);
+  jenv->DeleteLocalRef(local_ref);
 
   // We can just copy all the pointers to methods
   legalMovesTensorsMethodID = other.legalMovesTensorsMethodID;

--- a/games/ludii/ludii_state_wrapper.cc
+++ b/games/ludii/ludii_state_wrapper.cc
@@ -24,26 +24,6 @@ Action::Action(int i, int j, int k) {
 }
 
 void LudiiStateWrapper::Initialize() {
-
-  // In case we're calling this from a new thread, make sure that we're attached
-  // to JVM (following few lines based on:
-  // https://stackoverflow.com/a/12901159/6735980)
-  JavaVM* jvm;
-  jenv->GetJavaVM(&jvm);
-  int jenvStatus = jvm->GetEnv((void**)&jenv, JNI_VERSION_1_6);
-
-  if (jenvStatus == JNI_EDETACHED) {
-    //		std::cout << "Was not yet attached" << std::endl;
-    if (jvm->AttachCurrentThread((void**)&jenv, NULL) != 0) {
-      std::cout << "Failed to attach" << std::endl;
-    } else if (jenvStatus == JNI_EVERSION) {
-      std::cout << "JVM GetEnv: version not supported" << std::endl;
-    }
-    //		else {
-    //			std::cout << "Should be attached fine now" << std::endl;
-    //		}
-  }
-
   // Now do the normal initialisation
   Reset();
 
@@ -144,10 +124,9 @@ void LudiiStateWrapper::DoGoodAction() {
 // javap -s <ClassName.class>
 
 LudiiStateWrapper::LudiiStateWrapper(int seed,
-                                     JNIEnv* jenv,
                                      LudiiGameWrapper&& inLudiiGameWrapper)
     : ::State(seed)
-    , jenv(jenv) {
+    , jenv(JNIUtils::GetEnv()) {
 
   ludiiGameWrapper =
       std::make_shared<LudiiGameWrapper>(std::move(inLudiiGameWrapper));
@@ -192,7 +171,7 @@ LudiiStateWrapper::LudiiStateWrapper(int seed,
 
 LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
     : ::State(other)
-    , jenv(other.jenv)
+    , jenv(JNIUtils::GetEnv())
     , ludiiGameWrapper(other.ludiiGameWrapper) {
 
   jclass ludiiStateWrapperClass = JNIUtils::LudiiStateWrapperClass();

--- a/games/ludii/ludii_state_wrapper.h
+++ b/games/ludii/ludii_state_wrapper.h
@@ -122,10 +122,6 @@ class LudiiStateWrapper : public ::State {
   // operator)
   LudiiStateWrapper& operator=(LudiiStateWrapper const&) = delete;
 
-  /** Pointer to the JNI environment, allows for communication with Ludii's Java
-   * code */
-  JNIEnv* jenv;
-
   /** Pointer to our Game wrapper */
   std::shared_ptr<LudiiGameWrapper> ludiiGameWrapper;
 

--- a/games/ludii/ludii_state_wrapper.h
+++ b/games/ludii/ludii_state_wrapper.h
@@ -48,9 +48,7 @@ class LudiiStateWrapper : public ::State {
   /**
    * Constructor; calls the LudiiStateWrapper Java constructor
    */
-  LudiiStateWrapper(int seed,
-                    JNIEnv* jenv,
-                    LudiiGameWrapper&& inLudiiGameWrapper);
+  LudiiStateWrapper(int seed, LudiiGameWrapper&& inLudiiGameWrapper);
 
   /**
    * Copy constructor; calls the Java copy constructor for LudiiStateWrapper

--- a/tests/ludii-game-tests.cc
+++ b/tests/ludii-game-tests.cc
@@ -66,7 +66,7 @@ TEST(LudiiGameGroup, jni_init_1) {
 TEST(LudiiGameGroup, game_init_1) {
     if (JNI_ENV) {
         ASSERT_TRUE(JNI_ENV != 0);
-        Ludii::LudiiGameWrapper game(JNI_ENV, "/lud/board/space/line/Connect6.lud");
+        Ludii::LudiiGameWrapper game("/lud/board/space/line/Connect6.lud");
     }
 }
 


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes numerous memory leaks in the Ludii/Java integration, and potentially some issues with C++ threads accessing Java memory through the incorrect JEnv pointers.

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Prior to this, any training run with any Ludii game would have memory usage steadily increasing quite a lot, eventually causing the training to slow down to a crawl / almost completely freeze. After this, memory usage remains completely stable and training runs using Ludii games can run without any issues.

NOTE: this PR also includes the code from PR #48 , so that one no longer needs to be merged if this one is merged.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

Ran a traineval call with `--game_name="LudiiTic-Tac-Toe.lud"` and otherwise default params all the way to completion, without any issues. Tracked memory usages throughout and it remained stable. Also ran partial training runs with the extra -Xcheck:jni flag for the JVM to diagnose potential JNI issues, and fixed them.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
