### PR TITLE
[2/8] Big merge - core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.3)
-project(choufleur)
+project(polygames)
 
 # if(NOT CMAKE_BUILD_TYPE)
 #   set(CMAKE_BUILD_TYPE RelWithDebInfo)
@@ -7,7 +7,9 @@ project(choufleur)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-register -fPIC -march=native -O3 -Wfatal-errors")
+    "${CMAKE_CXX_FLAGS} -fsized-deallocation -O3 -ffast-math")
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 OPTION(PYTORCH12 "Is PyTorch >= 1.2" OFF)
 OPTION(PYTORCH15 "Is PyTorch >= 1.5" OFF)
@@ -46,57 +48,13 @@ endif()
 message(STATUS "Adding PyTorch compilation flags: ${TORCH_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
-include_directories(torchRL/third_party/fmt/include)
-add_subdirectory(torchRL/third_party/fmt)
-
-# add_subdirectory(torchRL)
-add_subdirectory(torchRL/third_party/pybind11)
-add_subdirectory(torchRL/tube)
-add_subdirectory(torchRL/mcts)
-
-set(SOURCES
-  games/gomoku_swap2.cc
-  games/othello_opt.cc
-  games/mastermind_state.cc
-  games/amazons.cc
-  games/breakthrough.cc
-  games/chess.cc
-  games/chinesecheckers.cc
-  games/tristan_nogo.cc
-  games/yinsh.cc
-  games/minesweeper.cc
-  games/weakschur/SchurMatrix.cpp
-  games/weakschur/SchurVector.cpp
-  games/weakschur/WeakSchur.cpp)
-
-if (JNI_FOUND)
-  list(APPEND SOURCES
-    games/ludii/jni_utils.cc
-    games/ludii/ludii_game_wrapper.cc
-    games/ludii/ludii_state_wrapper.cc)
-endif()
-
-add_library(_games
-  ${SOURCES})
-target_include_directories(_games PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/torchRL)
-target_include_directories(_games SYSTEM PUBLIC ${TORCH_INCLUDE_DIRS})
-target_include_directories(_games PUBLIC ${PYTHON_INCLUDE_DIRS})
-
-pybind11_add_module(polygames core/pybind.cc core/game.cc core/state.cc)
-
-target_include_directories(polygames PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/torchRL)
-target_link_libraries(polygames PUBLIC _tube _mcts _games)
-
-if (JNI_FOUND)
-  target_include_directories(_games PUBLIC ${JNI_INCLUDE_DIRS})
-  target_link_libraries(polygames PUBLIC ${JNI_LIBRARIES})
-endif()
+add_subdirectory(src)
 
 # add Minesweeper benchmarks
-add_subdirectory(games/minesweeper_csp_vkms)
+add_subdirectory(src/games/minesweeper_csp_vkms)
 
 # tests
-add_executable(test_state core/test_state.cc core/state.cc)
+add_executable(test_state src/core/test_state.cc src/core/state.cc)
 target_link_libraries(test_state PUBLIC _tube _mcts _games ${JNI_LIBRARIES})
 
 enable_testing()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,97 @@
+ 
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(third_party)
+include_directories(third_party/fmt/include)
+add_subdirectory(third_party/fmt)
+
+# add_subdirectory(torchRL)
+add_subdirectory(third_party/pybind11)
+add_subdirectory(tube)
+add_subdirectory(mcts)
+
+file(GLOB _zstd_SOURCES third_party/zstd/lib/common/*.c third_party/zstd/lib/compress/*.c third_party/zstd/lib/decompress/*.c)
+add_library(_zstd OBJECT ${_zstd_SOURCES})
+
+target_include_directories(_zstd PUBLIC third_party/zstd/lib third_party/zstd/lib/common)
+
+find_path(IBV_INCLUDE_DIR infiniband/verbs.h)
+find_library(IBV_LIBRARY ibverbs)
+
+add_library(libpolygames SHARED "")
+
+add_library(_distributed OBJECT
+  distributed/network.cc
+  distributed/distributed.cc
+)
+target_include_directories(_distributed SYSTEM PUBLIC ${TORCH_INCLUDE_DIRS})
+
+if (IBV_INCLUDE_DIR AND IBV_LIBRARY)
+  message(STATUS "Found ibverbs: ${IBV_INCLUDE_DIR}/infiniband/verbs.h ${IBV_LIBRARY}")
+  target_sources(_distributed PRIVATE
+    distributed/ib.cc)
+  target_include_directories(_distributed SYSTEM PUBLIC ${IBV_INCLUDE_DIR})
+  target_link_libraries(libpolygames PUBLIC ${IBV_LIBRARY})
+else()
+  message(STATUS "ibverbs NOT found, InfiniBand support will be disabled!")
+  target_sources(_distributed PRIVATE
+    distributed/rdma_nop.cc)
+endif()
+
+add_library(_common OBJECT
+  common/thread_id.cc
+  common/threads.cc
+  )
+
+set(_games_SOURCES
+  games/gomoku_swap2.cc
+  games/othello_opt.cc
+  games/mastermind_state.cc
+  games/amazons.cc
+  games/breakthrough.cc
+  games/chess.cc
+  games/chinesecheckers.cc
+  games/tristan_nogo.cc
+  games/yinsh.cc
+  games/minesweeper.cc
+  games/weakschur/SchurMatrix.cpp
+  games/weakschur/SchurVector.cpp
+  games/weakschur/WeakSchur.cpp)
+
+if (JNI_FOUND)
+  list(APPEND _games_SOURCES
+    games/ludii/jni_utils.cc
+    games/ludii/ludii_game_wrapper.cc
+    games/ludii/ludii_state_wrapper.cc)
+endif()
+
+add_library(_games
+  ${_games_SOURCES})
+target_include_directories(_games PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/torchRL)
+target_include_directories(_games SYSTEM PUBLIC ${TORCH_INCLUDE_DIRS})
+target_include_directories(_games PUBLIC ${PYTHON_INCLUDE_DIRS})
+
+target_sources(libpolygames PRIVATE
+  core/game.cc
+  core/state.cc
+  core/replay_buffer.cc
+  core/model_manager.cc
+  $<TARGET_OBJECTS:_zstd>
+  $<TARGET_OBJECTS:_distributed>
+  $<TARGET_OBJECTS:_common>
+)
+
+target_include_directories(libpolygames PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/torchRL)
+target_link_libraries(libpolygames PUBLIC _tube _mcts _games)
+set_target_properties(libpolygames PROPERTIES PREFIX "")
+
+if (JNI_FOUND)
+  target_include_directories(_games PUBLIC ${JNI_INCLUDE_DIRS})
+  target_link_libraries(libpolygames PUBLIC ${JNI_LIBRARIES})
+endif()
+
+
+pybind11_add_module(polygames
+  core/pybind.cc
+)
+target_link_libraries(polygames PUBLIC libpolygames)

--- a/src/common/async.h
+++ b/src/common/async.h
@@ -1,0 +1,337 @@
+#pragma once
+
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <future>
+#include <list>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#ifdef _POSIX_C_SOURCE
+#include <semaphore.h>
+#endif
+
+namespace async {
+
+#ifdef _POSIX_C_SOURCE
+class Semaphore {
+  sem_t sem;
+
+ public:
+  Semaphore() {
+    sem_init(&sem, 0, 0);
+  }
+  ~Semaphore() {
+    sem_destroy(&sem);
+  }
+  void post() {
+    sem_post(&sem);
+  }
+  void wait() {
+    sem_wait(&sem);
+  }
+};
+#else
+class Semaphore {
+  int count_ = 0;
+  std::mutex mut_;
+  std::condition_variable cv_;
+
+ public:
+  void post() {
+    std::unique_lock l(mut_);
+    if (++count_ >= 1) {
+      cv_.notify_one();
+    }
+  }
+  void wait() {
+    std::unique_lock l(mut_);
+    while (count_ == 0) {
+      cv_.wait(l);
+    }
+    --count_;
+  }
+};
+#endif
+
+struct Function {
+  Function* next = nullptr;
+  int priority = 0;
+  void* storage;
+  size_t allocated = 0;
+  void (*dtor)(void*);
+  void (*call)(void*);
+  Function() = default;
+  Function(const Function&) = delete;
+  Function& operator=(const Function&) = delete;
+  Function(Function&& n) {
+    storage = n.storage;
+    allocated = n.allocated;
+    dtor = n.dtor;
+    call = n.call;
+    n.storage = nullptr;
+  }
+  Function& operator=(Function&& n) {
+    std::swap(storage, n.storage);
+    std::swap(allocated, n.allocated);
+    std::swap(dtor, n.dtor);
+    std::swap(call, n.call);
+    return *this;
+  }
+  template <typename F> Function(F&& f) {
+    storage = std::malloc(sizeof(F));
+    if (!storage) {
+      throw std::bad_alloc();
+    }
+    allocated = sizeof(F);
+    try {
+      new (storage) F(std::forward<F>(f));
+    } catch (...) {
+      std::free(storage);
+      throw;
+    }
+    dtor = [](void* ptr) noexcept {
+      ((F*)ptr)->~F();
+    };
+    call = [](void* ptr) noexcept {
+      (*(F*)ptr)();
+    };
+  }
+  template <typename F> Function& operator=(F&& f) {
+    if (allocated < sizeof(F)) {
+      void* newStorage = std::malloc(sizeof(F));
+      if (!newStorage) {
+        throw std::bad_alloc();
+      }
+      if (storage) {
+        dtor(storage);
+        std::free(storage);
+      }
+      storage = newStorage;
+      allocated = sizeof(F);
+    } else {
+      if (storage) {
+        dtor(storage);
+      }
+    }
+    try {
+      new (storage) F(std::forward<F>(f));
+    } catch (...) {
+      std::free(storage);
+      throw;
+    }
+    dtor = [](void* ptr) { ((F*)ptr)->~F(); };
+    call = [](void* ptr) { (*(F*)ptr)(); };
+
+    return *this;
+  }
+  ~Function() {
+    if (storage) {
+      dtor(storage);
+      std::free(storage);
+    }
+  }
+  void operator()() {
+    call(storage);
+  }
+};
+
+template <typename Thread> struct HandleT {
+  Function* func = nullptr;
+  Thread* thread = nullptr;
+  HandleT() = default;
+  HandleT(Function* func, Thread* thread)
+      : func(func)
+      , thread(thread) {
+  }
+  HandleT(HandleT&& n) {
+    func = std::exchange(n.func, nullptr);
+    thread = std::exchange(n.thread, nullptr);
+  }
+  HandleT(const HandleT&) = delete;
+  HandleT& operator=(HandleT&& n) {
+    std::swap(func, n.func);
+    std::swap(thread, n.thread);
+    return *this;
+  }
+  HandleT& operator=(const HandleT&) = delete;
+  ~HandleT() {
+    if (func) {
+      Function* ftmp = thread->freelist;
+      do {
+        func->next = ftmp;
+      } while (!thread->freelist.compare_exchange_weak(ftmp, func));
+    }
+  }
+  void setPriority(int value) {
+    func->priority = value;
+  }
+  explicit operator bool() const {
+    return func;
+  }
+};
+
+using Handle = HandleT<struct Thread>;
+
+struct Thread {
+
+  std::thread thread;
+  std::atomic<Function*> queue = nullptr;
+  std::atomic<Function*> freelist = nullptr;
+  Function* internalqueue = nullptr;
+  bool dead = false;
+
+  Semaphore sem;
+
+  Thread() = default;
+
+  void threadEntry() {
+    while (true) {
+      Function* f = queue;
+      while (!f) {
+        if (dead) {
+          return;
+        }
+        sem.wait();
+        f = queue;
+      }
+      while (!queue.compare_exchange_weak(f, f->next))
+        ;
+      if (internalqueue || queue) {
+        do {
+          while (f) {
+            Function** insert = &internalqueue;
+            Function* next = internalqueue;
+            while (next && next->priority <= f->priority) {
+              insert = &next->next;
+              next = next->next;
+            }
+            f->next = next;
+            *insert = f;
+
+            f = queue;
+            while (f && !queue.compare_exchange_weak(f, f->next))
+              ;
+          }
+
+          f = internalqueue;
+          internalqueue = f->next;
+
+          (*f)();
+
+          f = queue;
+          while (f && !queue.compare_exchange_weak(f, f->next))
+            ;
+        } while (f || internalqueue);
+      } else {
+        (*f)();
+      }
+    }
+  }
+
+  void enqueue(Function* func) {
+    Function* qtmp = queue;
+    do {
+      func->next = qtmp;
+    } while (!queue.compare_exchange_weak(qtmp, func));
+    sem.post();
+  }
+
+  template <typename F> Handle getHandle(F&& f) {
+    Function* func = freelist;
+    while (func && !freelist.compare_exchange_weak(func, func->next))
+      ;
+    if (!func) {
+      func = new Function();
+    }
+    Handle h(func, this);
+    *func = std::forward<F>(f);
+    return h;
+  }
+};
+
+struct Threads {
+
+  std::atomic_size_t nextThread = 0;
+  std::deque<Thread> threads;
+
+  size_t size() const {
+    return threads.size();
+  }
+
+  Thread& getThread() {
+    return threads[nextThread++ % threads.size()];
+  }
+
+  void enqueue(const Handle& h) {
+    h.thread->enqueue(h.func);
+  }
+
+  Threads() = default;
+  Threads(int nThreads) {
+    start(nThreads);
+  }
+
+  void start(int nThreads) {
+    for (int i = 0; i != nThreads; ++i) {
+      threads.emplace_back();
+      Thread* t = &threads.back();
+      threads.back().thread = std::thread([t]() { t->threadEntry(); });
+    }
+  }
+
+  ~Threads() {
+    for (auto& v : threads) {
+      v.dead = true;
+      v.sem.post();
+    }
+    for (auto& v : threads) {
+      v.thread.join();
+    }
+  }
+};
+
+struct Task {
+  Semaphore sem;
+  std::atomic_int liveCount{0};
+
+  Threads* threads = nullptr;
+  Task() = default;
+  Task(Threads& threads)
+      : threads(&threads) {
+  }
+  ~Task() {
+    wait();
+  }
+  Task& operator=(const Task& n) {
+    if (liveCount || n.liveCount) {
+      throw std::runtime_error("attempt to copy active Task object");
+    }
+    threads = n.threads;
+    return *this;
+  }
+
+  template <typename F> Handle getHandle(Thread& thread, F&& f) {
+    return thread.getHandle([f = std::forward<F>(f), this]() mutable {
+      f();
+      if (--liveCount == 0) {
+        sem.post();
+      }
+    });
+  }
+
+  void enqueue(const Handle& h) {
+    ++liveCount;
+    threads->enqueue(h);
+  }
+
+  void wait() {
+    while (liveCount.load(std::memory_order_relaxed) != 0) {
+      sem.wait();
+    }
+  }
+};
+
+}  // namespace async

--- a/src/common/thread_id.cc
+++ b/src/common/thread_id.cc
@@ -1,0 +1,15 @@
+
+#include <atomic>
+
+namespace {
+std::atomic_int threadIdCounter{0};
+thread_local int threadId = ++threadIdCounter;
+}  // namespace
+
+namespace common {
+
+int getThreadId() {
+  return threadId;
+}
+
+}  // namespace common

--- a/src/common/thread_id.h
+++ b/src/common/thread_id.h
@@ -1,0 +1,5 @@
+
+namespace common {
+
+int getThreadId();
+}

--- a/src/common/threads.cc
+++ b/src/common/threads.cc
@@ -1,0 +1,52 @@
+
+#include "threads.h"
+
+namespace threads {
+
+async::Threads threads;
+std::once_flag flag;
+
+void init(int nThreads) {
+
+  std::call_once(
+      flag,
+      [](int nThreads) {
+        if (nThreads <= 0) {
+          nThreads = std::thread::hardware_concurrency();
+          if (nThreads <= 0) {
+            throw std::runtime_error("Could not automatically determine the "
+                                     "number of hardware threads :(");
+          }
+          printf("Starting %d threads (automatically configured)\n", nThreads);
+        } else {
+          printf("Starting %d threads\n", nThreads);
+        }
+
+        threads.start(nThreads);
+
+        async::Task task(threads);
+        std::vector<async::Handle> handles;
+
+        for (int i = 0; i != nThreads; ++i) {
+          auto& thread = threads.getThread();
+          auto h = task.getHandle(thread, [i]() {
+            setCurrentThreadName("async " + std::to_string(i));
+          });
+          task.enqueue(h);
+          handles.push_back(std::move(h));
+        }
+
+        task.wait();
+      },
+      nThreads);
+}
+
+void setCurrentThreadName(const std::string& name) {
+#ifdef __APPLE__
+  pthread_setname_np(name.c_str());
+#elif __linux__
+  pthread_setname_np(pthread_self(), name.c_str());
+#endif
+}
+
+}  // namespace threads

--- a/src/common/threads.h
+++ b/src/common/threads.h
@@ -1,0 +1,13 @@
+
+#include "async.h"
+
+#include <string>
+
+namespace threads {
+
+extern async::Threads threads;
+
+void init(int nThreads);
+void setCurrentThreadName(const std::string& name);
+
+}  // namespace threads

--- a/src/core/actor.h
+++ b/src/core/actor.h
@@ -7,44 +7,83 @@
 
 #pragma once
 
-#include "tube/src_cpp/channel_assembler.h"
+#include "model_manager.h"
 #include "tube/src_cpp/data_block.h"
 #include "tube/src_cpp/dispatcher.h"
-
-#include "mcts/actor.h"
 
 #include "state.h"
 #include "utils.h"
 
 //#define DEBUG_ACTOR
 
-class Actor : public mcts::Actor {
+namespace core {
+
+class PiVal {
+ public:
+  PiVal() {
+    reset();
+  }
+
+  void reset() {
+    playerId = -999;
+    value = 0.0f;
+    logitPolicy.reset();
+    rnnState.reset();
+  }
+
+  int playerId;
+  float value;
+  torch::Tensor logitPolicy;
+  torch::Tensor rnnState;
+};
+
+class Actor {
  public:
   Actor(std::shared_ptr<tube::DataChannel> dc,
         const std::vector<int64_t>& featSize,
         const std::vector<int64_t>& actionSize,
+        const std::vector<int64_t>& rnnStateSize,
+        int rnnSeqlen,
+        bool logitValue,
         bool useValue,
         bool usePolicy,
-        std::shared_ptr<tube::ChannelAssembler> assembler)
+        std::shared_ptr<ModelManager> modelManager)
       : dispatcher_(std::move(dc))
       , useValue_(useValue)
       , usePolicy_(usePolicy)
       , policySize_(actionSize)
       , uniformPolicy_(1.0 / product(actionSize))
-      , assembler_(assembler) {
+      , rnnStateSize_(rnnStateSize)
+      , rnnSeqlen_(rnnSeqlen)
+      , logitValue_(logitValue)
+      , modelManager_(modelManager) {
     if (!useValue && !usePolicy_) {
       return;
     }
 
     feat_ = std::make_shared<tube::DataBlock>("s", featSize, torch::kFloat32);
-    pi_ = std::make_shared<tube::DataBlock>("pi", actionSize, torch::kFloat32);
+    pi_ = std::make_shared<tube::DataBlock>(
+        "pi_logit", actionSize, torch::kFloat32);
     value_ = std::make_shared<tube::DataBlock>(
-        "v", std::initializer_list<int64_t>{1}, torch::kFloat32);
+        "v", std::initializer_list<int64_t>{logitValue ? 3 : 1},
+        torch::kFloat32);
 
-    dispatcher_.addDataBlocks({feat_}, {pi_, value_});
+    if (!rnnStateSize.empty()) {
+      rnnState_ = std::make_shared<tube::DataBlock>(
+          "rnn_state", rnnStateSize, torch::kFloat32);
+      rnnStateOut_ = std::make_shared<tube::DataBlock>(
+          "rnn_state_out", rnnStateSize, torch::kFloat32);
+    }
+
+    if (rnnStateSize.empty()) {
+      dispatcher_.addDataBlocks({feat_}, {pi_, value_});
+    } else {
+      dispatcher_.addDataBlocks(
+          {feat_, rnnState_}, {pi_, value_, rnnStateOut_});
+    }
   }
 
-  mcts::PiVal evaluate(const mcts::State& s) override {
+  PiVal& evaluate(const core::State& s, PiVal& pival) {
     const auto state = dynamic_cast<const State*>(&s);
     assert(state != nullptr);
 
@@ -76,7 +115,14 @@ class Actor : public mcts::Actor {
     float val;
     torch::Tensor policy;
     if (useValue_ && resultsAreValid) {
-      val = value_->data.item<float>();
+      if (logitValue_) {
+        float* begin = value_->data.data_ptr<float>();
+        float* end = begin + 3;
+        softmax_(begin, end);
+      }
+      val = logitValue_
+                ? value_->data[0].item<float>() - value_->data[1].item<float>()
+                : value_->data.item<float>();
     } else {
       val = state->getRandomRolloutReward(state->getCurrentPlayer());
     }
@@ -87,73 +133,113 @@ class Actor : public mcts::Actor {
       policy.fill_(uniformPolicy_);
     }
 
-    auto a2pi = getLegalPi(*state, policy);
-    return mcts::PiVal(state->getCurrentPlayer(), val, std::move(a2pi));
+    pival.logitPolicy = policy.clone();
+    pival.playerId = state->getCurrentPlayer();
+    pival.value = val;
+    if (rnnStateOut_) {
+      pival.rnnState = rnnStateOut_->data.clone();
+    }
+    return pival;
   }
 
-  void terminate() override {
+  void terminate() {
     dispatcher_.terminate();
   }
 
-  void evaluate(
-      const std::vector<const mcts::State*>& s,
-      const std::function<void(size_t, mcts::PiVal)>& resultCallback) override {
-
-    if (!assembler_) {
-      return mcts::Actor::evaluate(s, resultCallback);
-    }
-
+  void batchResize(size_t n) {
     if (!batchFeat_.defined() || batchFeat_[0].sizes() != feat_->data.sizes() ||
-        batchFeat_.size(0) < (int)s.size()) {
+        batchFeat_.size(0) < n) {
       auto allocBatch = [&](auto&& sizes) {
         std::vector<int64_t> s1(sizes.begin(), sizes.end());
-        s1.insert(s1.begin(), s.size());
-        return torch::empty(s1);
+        s1.insert(s1.begin(), n);
+        if (modelManager_ && modelManager_->isCuda()) {
+          return torch::empty(
+              s1, at::TensorOptions().pinned_memory(true).requires_grad(false));
+        } else {
+          return torch::empty(s1, at::TensorOptions().requires_grad(false));
+        }
       };
       batchFeat_ = allocBatch(feat_->data.sizes());
       batchPi_ = allocBatch(pi_->data.sizes());
       batchValue_ = allocBatch(value_->data.sizes());
-    }
 
+      valueAcc_ = batchValue_.accessor<float, 2>();
+      piAcc_ = batchPi_.accessor<float, 4>();
+      featAcc_ = batchFeat_.accessor<float, 4>();
+    }
+    if (rnnState_) {
+      rnnStateStack_.resize(n);
+    }
+  }
+  void batchPrepare(size_t index,
+                    const core::State& s,
+                    torch::Tensor rnnState) {
+    if (!modelManager_) {
+      if (rnnState.defined()) {
+        rnnState_->data.copy_(rnnState);
+      }
+      return;
+    }
+    getFeatureInTensor(*dynamic_cast<const State*>(&s), featAcc_[index].data());
+    if (!useValue_) {
+      batchValue_[index][0] = s.getRandomRolloutReward(s.getCurrentPlayer());
+    }
+    if (rnnState.defined()) {
+      if (rnnState.device() != device()) {
+        rnnState = rnnState.to(device());
+      }
+      rnnStateStack_.at(index) = rnnState;
+    }
+  }
+  void batchEvaluate(size_t n) {
+    if (!modelManager_) {
+      return;
+    }
     if (useValue_ || usePolicy_) {
-      auto featAcc = batchFeat_.accessor<float, 4>();
-      for (size_t i = 0; i != s.size(); ++i) {
-        getFeatureInTensor(
-            *dynamic_cast<const State*>(s[i]), featAcc[i].data());
-      }
-      auto id = assembler_->batchAct(batchFeat_.slice(0, 0, s.size()),
-                                     batchValue_.slice(0, 0, s.size()),
-                                     batchPi_.slice(0, 0, s.size()));
-    }
-
-    auto valueAcc = batchValue_.accessor<float, 2>();
-    auto piAcc = batchPi_.accessor<float, 4>();
-
-    if (!usePolicy_) {
-      batchPi_.fill_(uniformPolicy_);
-    }
-
-    for (size_t i = 0; i != s.size(); ++i) {
-      auto* state = s[i];
-      float val;
-      if (useValue_) {
-        val = valueAcc[i][0];
+      if (rnnState_) {
+        modelManager_->batchAct(
+            batchFeat_.narrow(0, 0, n), batchValue_.narrow(0, 0, n),
+            batchPi_.narrow(0, 0, n), torch::stack(rnnStateStack_),
+            &batchRnnStateOut_);
       } else {
-        val = state->getRandomRolloutReward(state->getCurrentPlayer());
+        modelManager_->batchAct(batchFeat_.narrow(0, 0, n),
+                                batchValue_.narrow(0, 0, n),
+                                batchPi_.narrow(0, 0, n));
       }
-      auto a2pi = getLegalPi(*dynamic_cast<const State*>(state), piAcc[i]);
-      resultCallback(
-          i, mcts::PiVal(state->getCurrentPlayer(), val, std::move(a2pi)));
+    }
+  }
+  void batchResult(size_t index, const core::State& s, PiVal& pival) {
+    if (!modelManager_) {
+      evaluate(s, pival);
+      return;
+    }
+    if (logitValue_) {
+      float* begin = &valueAcc_[index][0];
+      float* end = begin + 3;
+      softmax_(begin, end);
+    }
+    float val = logitValue_ ? valueAcc_[index][0] - valueAcc_[index][1]
+                            : valueAcc_[index][0];
+    pival.logitPolicy = batchPi_[index].clone();
+    pival.playerId = s.getCurrentPlayer();
+    pival.value = val;
+    if (rnnState_) {
+      pival.rnnState = batchRnnStateOut_[index];
     }
   }
 
-  virtual void recordMove(const mcts::State* state) override {
-    auto id = assembler_->getTournamentModelId();
+  void recordMove(const core::State* state) {
+    auto id = modelManager_->getTournamentModelId();
     ++modelTrackers_[state][id];
   }
 
-  virtual void result(const mcts::State* state, float reward) override {
-    if (assembler_) {
+  std::string getModelId() const {
+    return modelManager_ ? std::string(modelManager_->getTournamentModelId())
+                         : "dev";
+  }
+
+  void result(const core::State* state, float reward) {
+    if (modelManager_) {
       auto i = modelTrackers_.find(state);
       if (i != modelTrackers_.end()) {
         auto m = std::move(i->second);
@@ -164,14 +250,61 @@ class Actor : public mcts::Actor {
         for (auto& v : m) {
           v.second /= sum;
         }
-        assembler_->result(reward, std::move(m));
+        modelManager_->result(reward, std::move(m));
         modelTrackers_.erase(i);
       }
     }
   }
 
-  virtual bool isTournamentOpponent() const override {
-    return assembler_ ? assembler_->isTournamentOpponent() : false;
+  void forget(const core::State* state) {
+    if (modelManager_) {
+      auto i = modelTrackers_.find(state);
+      if (i != modelTrackers_.end()) {
+        modelTrackers_.erase(i);
+      }
+    }
+  }
+
+  bool isTournamentOpponent() const {
+    return modelManager_ ? modelManager_->isTournamentOpponent() : false;
+  }
+
+  bool wantsTournamentResult() const {
+    return modelManager_ ? modelManager_->wantsTournamentResult() : false;
+  }
+
+  std::vector<int64_t> rnnStateSize() const {
+    return rnnStateSize_;
+  }
+
+  int rnnSeqlen() const {
+    return rnnSeqlen_;
+  }
+
+  int vOutputs() const {
+    return logitValue_ ? 3 : 1;
+  }
+
+  int findBatchSize(const core::State& state) const {
+    if (modelManager_) {
+      if (rnnState_) {
+        return modelManager_->findBatchSize(
+            getFeatureInTensor(*dynamic_cast<const State*>(&state)),
+            torch::zeros(rnnStateSize_));
+      } else {
+        return modelManager_->findBatchSize(
+            getFeatureInTensor(*dynamic_cast<const State*>(&state)));
+      }
+    }
+    return 0;
+  }
+
+  bool isCuda() const {
+    return modelManager_ ? modelManager_->isCuda() : false;
+  }
+
+  torch::Device device() const {
+    return modelManager_ ? modelManager_->device() : torch::Device(torch::kCPU);
   }
 
  private:
@@ -180,19 +313,35 @@ class Actor : public mcts::Actor {
   std::shared_ptr<tube::DataBlock> feat_;
   std::shared_ptr<tube::DataBlock> pi_;
   std::shared_ptr<tube::DataBlock> value_;
+  std::shared_ptr<tube::DataBlock> rnnState_;
+  std::shared_ptr<tube::DataBlock> rnnStateOut_;
 
   const bool useValue_;
   const bool usePolicy_;
   const std::vector<int64_t> policySize_;
   const float uniformPolicy_;
 
-  std::shared_ptr<tube::ChannelAssembler> assembler_;
-
   torch::Tensor batchFeat_;
   torch::Tensor batchPi_;
   torch::Tensor batchValue_;
 
-  std::unordered_map<const mcts::State*,
+  torch::Tensor batchRnnStateOut_;
+
+  torch::TensorAccessor<float, 2> valueAcc_{nullptr, nullptr, nullptr};
+  torch::TensorAccessor<float, 4> piAcc_{nullptr, nullptr, nullptr};
+  torch::TensorAccessor<float, 4> featAcc_{nullptr, nullptr, nullptr};
+
+  std::vector<torch::Tensor> rnnStateStack_;
+  torch::Tensor rnnStateStackResult_;
+
+  std::unordered_map<const core::State*,
                      std::unordered_map<std::string_view, float>>
       modelTrackers_;
+
+  const std::vector<int64_t> rnnStateSize_;
+  int rnnSeqlen_ = 0;
+  bool logitValue_ = false;
+  std::shared_ptr<ModelManager> modelManager_;
 };
+
+}  // namespace core

--- a/src/core/actor_player.h
+++ b/src/core/actor_player.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "actor.h"
+#include "player.h"
+
+namespace core {
+
+class ActorPlayer : public Player {
+ public:
+  ActorPlayer()
+      : Player(false) {
+  }
+
+  void setActor(std::shared_ptr<Actor> actor) {
+    actor_ = std::move(actor);
+  }
+
+  void recordMove(const core::State* state) {
+    actor_->recordMove(state);
+  }
+
+  void result(const core::State* state, float reward) {
+    actor_->result(state, reward);
+  }
+
+  void forget(const core::State* state) {
+    actor_->forget(state);
+  }
+
+  bool isTournamentOpponent() const {
+    return actor_->isTournamentOpponent();
+  }
+
+  bool wantsTournamentResult() const {
+    return actor_->wantsTournamentResult();
+  }
+
+  std::string getModelId() const {
+    return actor_->getModelId();
+  }
+
+  float calculateValue(const core::State& state) {
+    PiVal result;
+    actor_->evaluate(state, result);
+    return result.value;
+  }
+
+  std::vector<torch::Tensor> nextRnnState(
+      const std::vector<const core::State*>& state,
+      const std::vector<torch::Tensor>& rnnState) {
+    PiVal result;
+    actor_->batchResize(state.size());
+    for (size_t i = 0; i != state.size(); ++i) {
+      actor_->batchPrepare(i, *state[i], rnnState[i]);
+    }
+    actor_->batchEvaluate(state.size());
+    std::vector<torch::Tensor> r;
+    for (size_t i = 0; i != state.size(); ++i) {
+      actor_->batchResult(i, *state[i], result);
+      r.push_back(result.rnnState);
+    }
+    return r;
+  }
+
+  std::vector<int64_t> rnnStateSize() const {
+    return actor_->rnnStateSize();
+  }
+
+  int rnnSeqlen() const {
+    return actor_->rnnSeqlen();
+  }
+
+  int vOutputs() const {
+    return actor_->vOutputs();
+  }
+
+  int findBatchSize(const core::State& state) const {
+    return actor_->findBatchSize(state);
+  }
+
+  virtual void terminate() override {
+    if (actor_) {
+      actor_->terminate();
+    }
+  }
+
+ protected:
+  std::shared_ptr<Actor> actor_;
+};
+
+}  // namespace core

--- a/src/core/forward_player.h
+++ b/src/core/forward_player.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "actor_player.h"
+
+namespace core {
+
+class ForwardPlayer : public ActorPlayer {
+ public:
+  void batchResize(size_t n) {
+    actor_->batchResize(n);
+  }
+  void batchPrepare(size_t index, const State& s, torch::Tensor rnnState) {
+    actor_->batchPrepare(index, s, rnnState);
+  }
+  void batchEvaluate(size_t n) {
+    actor_->batchEvaluate(n);
+  }
+  void batchResult(size_t index, const State& s, PiVal& pival) {
+    actor_->batchResult(index, s, pival);
+  }
+};
+
+}  // namespace core

--- a/src/core/game.cc
+++ b/src/core/game.cc
@@ -6,103 +6,782 @@
  */
 
 #include "game.h"
+#include "common/thread_id.h"
+#include "common/threads.h"
+#include "forward_player.h"
+#include "utils.h"
 
 #include <fmt/printf.h>
 
-void Game::mainLoop() {
-  if (players_.size() != (isOnePlayerGame() ? 1 : 2)) {
-    std::cout << "Error: wrong number of players: " << players_.size()
-              << std::endl;
-    assert(false);
+namespace core {
+
+struct BatchExecutor {
+
+  struct MoveHistory {
+    int turn = 0;
+    uint64_t move = 0;
+    float value = 0.0f;
+    torch::Tensor shortFeat;
+    bool featurized = false;
+  };
+
+  struct Sequence {
+    std::vector<torch::Tensor> feat;
+    std::vector<torch::Tensor> v;
+    std::vector<torch::Tensor> pi;
+    std::vector<torch::Tensor> piMask;
+    std::vector<torch::Tensor> actionPi;
+    std::vector<torch::Tensor> predV;
+    torch::Tensor rnnInitialState;
+    std::vector<torch::Tensor> rnnStateMask;
+    std::vector<torch::Tensor> predictPi;
+    std::vector<torch::Tensor> predictPiMask;
+  };
+
+  struct GameState {
+    std::unique_ptr<State> state;
+    std::vector<std::unique_ptr<State>> playerState;
+    std::vector<size_t> players;
+    std::vector<size_t> playersReverseMap;
+    std::vector<std::vector<torch::Tensor>> feat;
+    std::vector<std::vector<torch::Tensor>> pi;
+    std::vector<std::vector<torch::Tensor>> piMask;
+    std::vector<std::vector<torch::Tensor>> rnnStates;
+    std::vector<std::vector<torch::Tensor>> actionPi;
+    std::vector<std::vector<torch::Tensor>> predV;
+    std::vector<std::vector<float>> reward;
+    size_t stepindex;
+    std::chrono::steady_clock::time_point start;
+    std::vector<int> resignCounter;
+    int drawCounter = 0;
+    bool canResign = false;
+    int resigned = -1;
+    bool drawn = false;
+    std::chrono::steady_clock::time_point prevMoveTime =
+        std::chrono::steady_clock::now();
+    std::vector<size_t> playerOrder;
+    std::vector<MoveHistory> history;
+    bool justRewound = false;
+    bool justRewoundToNegativeValue = false;
+    int rewindCount = 0;
+    std::vector<torch::Tensor> rnnState;
+    std::vector<torch::Tensor> rnnState2;
+
+    std::vector<int> allowRandomMoves;
+    bool validTournamentGame = false;
+
+    std::vector<size_t> startMoves;
+
+    int randMoveCount = 0;
+  };
+
+  Game* game = nullptr;
+  std::vector<Player*> players_;
+  std::unique_ptr<State> basestate;
+  std::minstd_rand rng{std::random_device{}()};
+  std::vector<Sequence> seqs;
+  std::list<GameState> states;
+  std::list<GameState> freeGameList;
+  int64_t startedGameCount = 0;
+  int64_t completedGameCount = 0;
+  float runningAverageGameSteps = 0.0f;
+  ActorPlayer* devPlayer = nullptr;
+  std::vector<ActorPlayer*> actorPlayers;
+  std::vector<mcts::MctsPlayer*> mctsPlayers;
+  std::vector<ForwardPlayer*> forwardPlayers;
+  std::vector<float> result_;
+  std::vector<std::vector<const State*>> actStates;
+  std::vector<std::vector<const State*>> actPlayerStates;
+  std::vector<std::vector<GameState*>> actGameStates;
+  std::vector<const State*> playerActStates;
+  bool alignPlayers = true;
+  std::vector<std::pair<size_t, size_t>> statePlayerSize;
+  std::vector<size_t> remapPlayerIdx;
+  async::Task task;
+  std::vector<torch::Tensor> actRnnState;
+  const mcts::MctsOption* mctsOption = nullptr;
+  std::vector<mcts::MctsResult> mctsResult;
+  mutable std::mutex recordMoveMutex;
+
+  int randint(int n) {
+    return std::uniform_int_distribution<int>(0, n - 1)(rng);
   }
-  if (perThreadBatchSize > 0) {
-    bool aHuman = std::any_of(players_.begin(), players_.end(),
-                              [](const std::shared_ptr<mcts::Player>& player) {
-                                return player->isHuman();
-                              });
-    if (aHuman && state_->stochasticReset()) {
-      std::string line;
-      std::cout << "Random outcome ?" << std::endl;
-      std::cin >> line;
-      state_->forcedDice = std::stoul(line, nullptr, 0);
-    }
-    reset();
 
-    auto basestate = std::move(state_);
+  std::unique_ptr<State> cloneState(const std::unique_ptr<State>& state) const {
+    return state->clone();
+  }
 
-    struct GameState {
-      std::unique_ptr<State> state;
-      std::vector<std::vector<torch::Tensor>> feat;
-      std::vector<std::vector<torch::Tensor>> pi;
-      std::vector<std::vector<torch::Tensor>> piMask;
-      size_t stepindex;
-      std::chrono::system_clock::time_point start;
-      std::vector<int> resignCounter;
-      bool canResign = false;
-      int resigned = -1;
-      std::chrono::steady_clock::time_point prevMoveTime =
-          std::chrono::steady_clock::now();
-    };
-
-    std::list<GameState> states;
-
-    size_t ngames = size_t(perThreadBatchSize);
-
-    int64_t startedGameCount = 0;
-    int64_t completedGameCount = 0;
-
-    std::minstd_rand rng(std::random_device{}());
-    auto randint = [&](int n) {
-      return std::uniform_int_distribution<int>(0, n - 1)(rng);
-    };
-
-    auto cloneState = [&](auto& state) {
-      auto x = state->clone();
-      auto n = dynamic_cast<State*>(x.get());
-      std::unique_ptr<State> r(n);
-      if (n) {
-        x.release();
+  void doRandomMoves(GameState& gst, int n) {
+    auto o = cloneState(gst.state);
+    std::vector<size_t> moves;
+    for (; n > 0; --n) {
+      if (gst.state->terminated()) {
+        break;
       }
-      return r;
-    };
+      size_t n = randint(gst.state->GetLegalActions().size());
+      moves.push_back(n);
+      gst.state->forward(n);
+    }
+    if (gst.state->terminated()) {
+      gst.state = std::move(o);
+    } else {
+      for (auto m : moves) {
+        for (auto& x : gst.playerState) {
+          if (x) {
+            x->forward(m);
+          }
+        }
+      }
+      // fmt::printf("Did %d random moves: '%s'\n", gst.state->getStepIdx(),
+      // gst.state->history());
+    }
+    gst.startMoves = std::move(moves);
+  };
 
-    auto addGame = [&](auto at) {
-      ++startedGameCount;
-      GameState gst;
-      gst.state = cloneState(basestate);
-      gst.feat.resize(players_.size());
-      gst.pi.resize(players_.size());
-      gst.piMask.resize(players_.size());
-      gst.stepindex = 0;
-      gst.start = std::chrono::system_clock::now();
-      gst.resignCounter.resize(players_.size());
-      gst.canResign = !evalMode && players_.size() == 2 && randint(3) != 0;
+  std::list<GameState>::iterator addGame(std::list<GameState>::iterator at) {
+    if (!freeGameList.empty()) {
+      GameState gst = std::move(freeGameList.front());
+      freeGameList.pop_front();
       return states.insert(at, std::move(gst));
-    };
+    }
+    ++startedGameCount;
+    GameState gst;
+    for (size_t i = 0; i != players_.size(); ++i) {
+      gst.players.push_back(i);
+    }
+    std::shuffle(gst.players.begin(), gst.players.end(), rng);
+    gst.playersReverseMap.resize(players_.size());
+    for (size_t i = 0; i != players_.size(); ++i) {
+      gst.playersReverseMap[gst.players[i]] = i;
+    }
+    gst.state = cloneState(basestate);
+    unsigned long seed = rng();
+    gst.state->newGame(seed);
+    gst.playerState.resize(players_.size());
+    for (size_t i = 0; i != players_.size(); ++i) {
+      std::unique_ptr<State> s = nullptr;
+      int index = gst.players[i];
+      if (&*game->playerGame_[index] != game) {
+        s = cloneState(game->playerGame_[index]->state_);
+        s->newGame(seed);
+      }
+      gst.playerState[i] = std::move(s);
+    }
+    gst.feat.resize(players_.size());
+    gst.pi.resize(players_.size());
+    gst.piMask.resize(players_.size());
+    gst.reward.resize(players_.size());
+    gst.rnnState.resize(players_.size());
+    gst.rnnState2.resize(players_.size());
+    gst.rnnStates.resize(players_.size());
+    gst.actionPi.resize(players_.size());
+    gst.predV.resize(players_.size());
+    gst.stepindex = 0;
+    gst.start = std::chrono::steady_clock::now();
+    gst.resignCounter.resize(players_.size());
+    gst.canResign = !game->evalMode && players_.size() == 2 && randint(3) != 0;
+    gst.validTournamentGame = true;
+    gst.allowRandomMoves.resize(players_.size());
+    for (auto& v : gst.allowRandomMoves) {
+      v = randint(4) == 0;
+    }
+    if (randint(250) == 0) {
+      switch (randint(2)) {
+      case 0:
+        doRandomMoves(gst, randint(std::max((int)runningAverageGameSteps, 1)));
+        break;
+      case 1:
+        doRandomMoves(
+            gst, randint(std::max((int)runningAverageGameSteps / 10, 1)));
+        break;
+      case 2:
+        doRandomMoves(
+            gst, randint(std::max((int)runningAverageGameSteps / 5, 1)));
+        break;
+      }
+      gst.validTournamentGame = false;
+    }
+    return states.insert(at, std::move(gst));
+  }
+
+  bool rewind(GameState* s, int player, bool rewindToNegativeValue) const {
+    if (s->history.size() <= 2) {
+      // fmt::printf("refusing to rewind with history size %d\n",
+      // s->history.size());
+      return false;
+    }
+    float flip = rewindToNegativeValue ? -1 : 1;
+    size_t index = 0;
+    for (index = s->history.size(); index;) {
+      --index;
+      auto& h = s->history[index];
+      if (h.turn == player && h.value * flip > 0) {
+        break;
+      }
+    }
+    if (index <= 2) {
+      // fmt::printf("refusing to rewind to index %d\n", index);
+      return false;
+    }
+    if (!s->rnnStates.empty() || !s->rnnState.empty() ||
+        !s->rnnState2.empty()) {
+      bool rnn = false;
+      for (auto& v : actorPlayers) {
+        if (v->rnnSeqlen()) {
+          rnn = true;
+        }
+      }
+      if (rnn) {
+        fmt::printf("Cannot currently rewind with rnn states, sorry :(\n");
+        return false;
+      }
+    }
+    fmt::printf("rewinding from %d to index %d\n", s->history.size(), index);
+    s->justRewound = true;
+    s->justRewoundToNegativeValue = rewindToNegativeValue;
+
+    auto& gst = *s;
+    gst.state = cloneState(basestate);
+
+    for (size_t i = 0; i != gst.playerState.size(); ++i) {
+      auto& x = gst.playerState[i];
+      if (x) {
+        int player = gst.players.at(i);
+        x = cloneState(game->playerGame_.at(player)->state_);
+      }
+    }
+
+    for (auto m : gst.startMoves) {
+      gst.state->forward(m);
+      for (auto& x : gst.playerState) {
+        if (x) {
+          x->forward(m);
+        }
+      }
+    }
+
+    for (auto& v : gst.feat) {
+      v.clear();
+    }
+    for (auto& v : gst.pi) {
+      v.clear();
+    }
+    for (auto& v : gst.piMask) {
+      v.clear();
+    }
+    for (auto& v : gst.reward) {
+      v.clear();
+    }
+    for (auto& v : gst.actionPi) {
+      v.clear();
+    }
+    for (auto& v : gst.predV) {
+      v.clear();
+    }
+    for (auto& v : gst.resignCounter) {
+      v = 0;
+    }
+    gst.drawCounter = 0;
+    gst.resigned = -1;
+    gst.drawn = false;
+
+    gst.history.resize(index);
+    for (auto& v : gst.history) {
+      v.featurized = false;
+      gst.state->forward(v.move);
+      for (auto& x : gst.playerState) {
+        if (x) {
+          x->forward(v.move);
+        }
+      }
+    }
+    return true;
+  }
+
+  using stateCallback = void (BatchExecutor::*)(GameState*,
+                                                int currentPlayerIndex,
+                                                size_t index) const;
+
+  void actPrepareRnn(GameState* gameState,
+                     int currentPlayerIndex,
+                     size_t index) const {
+    size_t slot = gameState->playersReverseMap.at(currentPlayerIndex);
+
+    if (!gameState->rnnState.at(slot).defined()) {
+      auto shape = actorPlayers.at(currentPlayerIndex)->rnnStateSize();
+      gameState->rnnState[slot] = torch::zeros(shape);
+    }
+
+    const_cast<torch::Tensor&>(actRnnState[index]) =
+        std::move(gameState->rnnState[slot]);
+    gameState->rnnState[slot].reset();
+
+    if (&*game->playerGame_.at(currentPlayerIndex) == game) {
+      gameState->rnnStates.at(slot).push_back(actRnnState[index].cpu());
+    }
+  }
+
+  void actPrepareForward(GameState* gameState,
+                         int currentPlayerIndex,
+                         size_t index) const {
+    auto* player = forwardPlayers.at(currentPlayerIndex);
+    if (actRnnState.empty()) {
+      player->batchPrepare(index, *gameState->state, {});
+    } else {
+      player->batchPrepare(index, *gameState->state, actRnnState.at(index));
+    }
+  }
+
+  void actResult(GameState* gameState,
+                 int currentPlayerIndex,
+                 size_t index) const {
+    State* state = &*gameState->state;
+    size_t slot = gameState->playersReverseMap.at(currentPlayerIndex);
+
+    if (gameState->rnnState.at(slot).defined()) {
+      throw std::runtime_error("rnnState is not empty error");
+    }
+    mcts::MctsPlayer* mctsPlayer = mctsPlayers[currentPlayerIndex];
+    ForwardPlayer* forwardPlayer = forwardPlayers[currentPlayerIndex];
+    PiVal pival;
+    int bestAction = -1;
+    float value = 0.0f;
+
+    thread_local std::mt19937_64 tlrng(std::random_device{}());
+
+    if (forwardPlayer) {
+      forwardPlayer->batchResult(index, *state, pival);
+
+      gameState->rnnState[slot] = std::move(pival.rnnState);
+
+      thread_local std::vector<float> x;
+      getLegalPi(*state, pival.logitPolicy, x);
+      softmax_(x);
+
+      bestAction = std::discrete_distribution(x.begin(), x.end())(tlrng);
+
+      int oa = state->overrideAction();
+      if (oa != -1) {
+        bestAction = oa;
+      }
+
+      value = pival.value;
+
+    } else if (mctsPlayer) {
+      gameState->rnnState[slot] = std::move(mctsResult.at(index).rnnState);
+      bestAction = mctsResult.at(index).bestAction;
+      value = mctsResult.at(index).rootValue;
+    } else {
+      throw std::runtime_error("unknown player");
+    }
+
+    if (gameState->canResign) {
+      if (value < -0.95f) {
+        if (++gameState->resignCounter.at(slot) >= 7) {
+          gameState->resigned = int(slot);
+        }
+      } else {
+        gameState->resignCounter.at(slot) = 0;
+      }
+      int opponent =
+          (gameState->playersReverseMap.at(currentPlayerIndex) + 1) % 2;
+      if (value > 0.95f) {
+        ++gameState->resignCounter.at(opponent);
+      } else {
+        gameState->resignCounter.at(opponent) = 0;
+      }
+
+      // Automatic draw disabled for now; this is not the best way to handle
+      // this
+      // TODO: enable this only for models with logit value outputs, since they
+      // have
+      //       a logit specific for draw - this would work best with MCTS
+      //       modification that allows backpropagating the draw probability
+      //      if (gameState->stepindex >= 40 && value >
+      //      -0.05 && value < 0.05) {
+      //        ++gameState->drawCounter;
+      //        if (gameState->drawCounter >= 7) {
+      //          gameState->drawn = true;
+      //        }
+      //      } else {
+      //        gameState->drawCounter = 0;
+      //      }
+    }
+    bool saveForTraining = true;
+    // TODO: improve this randomizedRollouts check, 1.5 is a magic number that
+    //       needs to be synchronized with mcts.cc
+    if (mctsOption && mctsOption->randomizedRollouts &&
+        mctsResult.at(index).rollouts <
+            mctsOption->numRolloutPerThread * 1.5f) {
+      saveForTraining = false;
+    }
+    if (saveForTraining) {
+      torch::Tensor feat = getFeatureInTensor(*state);
+      gameState->feat.at(slot).push_back(feat);
+      if (forwardPlayer) {
+        auto actionPolicy = torch::zeros_like(pival.logitPolicy);
+        auto action = state->GetLegalActions().at(bestAction);
+        actionPolicy[action.GetX()][action.GetY()][action.GetZ()] = 1;
+        gameState->actionPi.at(slot).push_back(actionPolicy);
+        gameState->pi.at(slot).push_back(pival.logitPolicy);
+        gameState->piMask.at(slot).push_back(getPolicyMaskInTensor(*state));
+      } else {
+        auto [policy, policyMask] =
+            getPolicyInTensor(*state, mctsResult.at(index).mctsPolicy);
+        gameState->pi.at(slot).push_back(policy);
+        gameState->piMask.at(slot).push_back(policyMask);
+      }
+      torch::Tensor predV = torch::zeros({1}, torch::kFloat32);
+      predV[0] = value;
+      gameState->predV.at(slot).push_back(predV);
+
+      gameState->reward[slot].push_back(state->getReward(slot));
+    }
+
+    gameState->history.emplace_back();
+    auto& h = gameState->history.back();
+    h.turn = slot;
+    h.move = bestAction;
+    h.value = value;
+    h.featurized = saveForTraining;
+    h.shortFeat = getRawFeatureInTensor(*state);
+
+    if (gameState->rewindCount == 0) {
+      std::lock_guard l(recordMoveMutex);
+      actorPlayers[currentPlayerIndex]->recordMove(state);
+    }
+
+    state->forward(bestAction);
+
+    auto now = std::chrono::steady_clock::now();
+    double elapsed = std::chrono::duration_cast<
+                         std::chrono::duration<double, std::ratio<1, 1>>>(
+                         now - gameState->prevMoveTime)
+                         .count();
+    gameState->prevMoveTime = now;
+
+    // fmt::printf("Thread %d: move took %gs\n", common::getThreadId(),
+    // elapsed);
+
+    {
+      std::unique_lock<std::mutex> lkStats(game->mutexStats_);
+      auto& stats_s = game->stats_["Move Duration (seconds)"];
+      std::get<0>(stats_s) += 1;
+      std::get<1>(stats_s) += elapsed;
+      std::get<2>(stats_s) += elapsed * elapsed;
+    }
+
+    if (gameState->justRewound) {
+      float flip = gameState->justRewoundToNegativeValue ? -1.0f : 1.0f;
+      if (h.value * flip < 0.0f) {
+        // fmt::printf("rewound turned negative, rewinding more!\n");
+        rewind(gameState, slot, gameState->justRewoundToNegativeValue);
+      } else {
+        gameState->justRewound = false;
+      }
+    }
+
+    // fmt::printf("game in progress: %s\n", state->history());
+  }
+
+  std::vector<stateCallback> stateCallbacks;
+
+  std::vector<async::Handle> taskHandles;
+
+  void prepareStateCallbacks() {
+    stateCallbacks.clear();
+    taskHandles.clear();
+    size_t offset = 0;
+    for (size_t pi = 0; pi != statePlayerSize.size(); ++pi) {
+      size_t currentPlayerIndex = statePlayerSize[pi].first;
+      size_t currentPlayerStates = statePlayerSize[pi].second;
+      for (size_t i = 0; i != currentPlayerStates; ++i) {
+        GameState* gameState = actGameStates.at(currentPlayerIndex).at(i);
+
+        auto f = [this, gameState, currentPlayerIndex, index = offset + i]() {
+          for (auto& cb : stateCallbacks) {
+            (this->*cb)(gameState, currentPlayerIndex, index);
+          }
+        };
+
+        auto& thread = threads::threads.getThread();
+        taskHandles.push_back(task.getHandle(thread, std::move(f)));
+        taskHandles.back().setPriority(common::getThreadId());
+      }
+      offset += currentPlayerStates;
+    }
+  }
+
+  void pushStateCallback(stateCallback cb) {
+    stateCallbacks.push_back(cb);
+  }
+
+  void runStateCallbacks() {
+    if (stateCallbacks.empty()) {
+      return;
+    }
+    for (auto& v : taskHandles) {
+      task.enqueue(v);
+    }
+    task.wait();
+  }
+
+  void actForPlayer(size_t playerIndex) {
+    // Merge all identical players so they get batched together
+    auto& states = actStates[playerIndex];
+    if (!states.empty()) {
+      statePlayerSize.clear();
+      statePlayerSize.emplace_back(playerIndex, states.size());
+      for (size_t i = 0; i != players_.size(); ++i) {
+        if (i != playerIndex && remapPlayerIdx[i] == playerIndex) {
+          auto& nstates = actStates[i];
+          if (!nstates.empty()) {
+            states.insert(states.end(), nstates.begin(), nstates.end());
+            statePlayerSize.emplace_back(i, nstates.size());
+            nstates.clear();
+          }
+        }
+      }
+      playerActStates.resize(states.size());
+      size_t offset = 0;
+      for (size_t pi = 0; pi != statePlayerSize.size(); ++pi) {
+        size_t currentPlayerIndex = statePlayerSize[pi].first;
+        size_t currentPlayerStates = statePlayerSize[pi].second;
+        for (size_t i = 0; i != currentPlayerStates; ++i) {
+          GameState* gameState = actGameStates.at(currentPlayerIndex).at(i);
+          int slot = gameState->playersReverseMap.at(currentPlayerIndex);
+          if (gameState->playerState.at(slot)) {
+            playerActStates.at(offset + i) = &*gameState->playerState[slot];
+          } else {
+            playerActStates.at(offset + i) = states.at(offset + i);
+          }
+        }
+        offset += currentPlayerStates;
+      }
+
+      prepareStateCallbacks();
+
+      if (actorPlayers.at(playerIndex)->rnnSeqlen()) {
+        actRnnState.resize(states.size());
+        pushStateCallback(&BatchExecutor::actPrepareRnn);
+      } else {
+        actRnnState.clear();
+      }
+
+      mctsResult.clear();
+
+      if (forwardPlayers.at(playerIndex)) {
+        forwardPlayers[playerIndex]->batchResize(states.size());
+        pushStateCallback(&BatchExecutor::actPrepareForward);
+        runStateCallbacks();
+        forwardPlayers[playerIndex]->batchEvaluate(states.size());
+      } else {
+
+        runStateCallbacks();
+
+        mctsResult =
+            mctsPlayers.at(playerIndex)->actMcts(playerActStates, actRnnState);
+      }
+
+      stateCallbacks.clear();
+
+      // allowRandomMoves support
+      // TODO: move into a state callback
+      if (mctsPlayers.at(playerIndex)) {
+        offset = 0;
+        for (size_t pi = 0; pi != statePlayerSize.size(); ++pi) {
+          size_t currentPlayerIndex = statePlayerSize[pi].first;
+          size_t currentPlayerStates = statePlayerSize[pi].second;
+          for (size_t i = 0; i != currentPlayerStates; ++i) {
+            State* state = (State*)states.at(offset + i);
+            GameState* gameState = actGameStates.at(currentPlayerIndex).at(i);
+
+            size_t slot = gameState->playersReverseMap.at(currentPlayerIndex);
+
+            if (gameState->allowRandomMoves.at(slot)) {
+              float x = 4.0f / std::pow(state->getStepIdx() + 10, 2.0f);
+              if (std::uniform_real_distribution<float>(0, 1.0f)(rng) < x) {
+                mctsResult.at(offset + i).bestAction =
+                    randint(state->GetLegalActions().size());
+                // fmt::printf("at state '%s' - performing random move %s\n",
+                // state->history(),
+                // state->actionDescription(state->GetLegalActions().at(mctsResult.at(offset
+                // + i).bestAction)));
+                gameState->validTournamentGame = false;
+              }
+            }
+          }
+          offset += currentPlayerStates;
+        }
+      }
+
+      // Support for running the opponent player in a different game
+      // implementation. This is rarely needed or used, but can be useful to
+      // train against a model that was trained on a different game
+      // implementation but with the same action space
+      // TODO: move into a state callback
+      if (&*game->playerGame_.at(playerIndex) != game) {
+        if (devPlayer->rnnSeqlen()) {
+          actRnnState.clear();
+
+          offset = 0;
+          for (size_t pi = 0; pi != statePlayerSize.size(); ++pi) {
+            size_t currentPlayerIndex = statePlayerSize[pi].first;
+            size_t currentPlayerStates = statePlayerSize[pi].second;
+            for (size_t i = 0; i != currentPlayerStates; ++i) {
+              GameState* gameState = actGameStates.at(currentPlayerIndex).at(i);
+
+              size_t slot = gameState->playersReverseMap.at(currentPlayerIndex);
+
+              if (!gameState->rnnState2.at(slot).defined()) {
+                gameState->rnnState2[slot] =
+                    torch::zeros(devPlayer->rnnStateSize());
+              }
+
+              actRnnState.push_back(std::move(gameState->rnnState2[slot]));
+
+              gameState->rnnStates.at(slot).push_back(actRnnState.back().cpu());
+            }
+            offset += currentPlayerStates;
+          }
+
+          std::vector<torch::Tensor> nextRnnState =
+              devPlayer->nextRnnState(states, actRnnState);
+
+          offset = 0;
+          for (size_t pi = 0; pi != statePlayerSize.size(); ++pi) {
+            size_t currentPlayerIndex = statePlayerSize[pi].first;
+            size_t currentPlayerStates = statePlayerSize[pi].second;
+            for (size_t i = 0; i != currentPlayerStates; ++i) {
+              GameState* gameState = actGameStates.at(currentPlayerIndex).at(i);
+
+              size_t slot = gameState->playersReverseMap.at(currentPlayerIndex);
+
+              gameState->rnnState2[slot] =
+                  std::move(nextRnnState.at(offset + i));
+            }
+            offset += currentPlayerStates;
+          }
+        }
+
+        offset = 0;
+        for (size_t pi = 0; pi != statePlayerSize.size(); ++pi) {
+          size_t currentPlayerStates = statePlayerSize[pi].second;
+          for (size_t i = 0; i != currentPlayerStates; ++i) {
+            State* state = (State*)playerActStates.at(offset + i);
+
+            auto& res = mctsResult.at(offset + i);
+
+            state->forward(res.bestAction);
+          }
+          offset += currentPlayerStates;
+        }
+
+      } else {
+        offset = 0;
+        for (size_t pi = 0; pi != statePlayerSize.size(); ++pi) {
+          size_t currentPlayerIndex = statePlayerSize[pi].first;
+          size_t currentPlayerStates = statePlayerSize[pi].second;
+          for (size_t i = 0; i != currentPlayerStates; ++i) {
+            GameState* gameState = actGameStates.at(currentPlayerIndex).at(i);
+            auto& res = mctsResult.at(offset + i);
+
+            for (auto& x : gameState->playerState) {
+              if (x) {
+                x->forward(res.bestAction);
+              }
+            }
+          }
+          offset += currentPlayerStates;
+        }
+      }
+
+      mctsOption = mctsPlayers[playerIndex]
+                       ? &mctsPlayers[playerIndex]->option()
+                       : nullptr;
+
+      if (mctsPlayers.at(playerIndex)) {
+        double rps = mctsPlayers.at(playerIndex)->rolloutsPerSecond();
+        std::unique_lock<std::mutex> lkStats(game->mutexStats_);
+        auto& stats_s = game->stats_["Rollouts per second"];
+        std::get<0>(stats_s) += 1;
+        std::get<1>(stats_s) += rps;
+        std::get<2>(stats_s) += rps * rps;
+      }
+
+      pushStateCallback(&BatchExecutor::actResult);
+
+      runStateCallbacks();
+
+      states.clear();
+    }
+  }
+
+  void run() {
+
+    task = async::Task(threads::threads);
+
+    for (auto& v : game->players_) {
+      players_.push_back(&*v);
+    }
+
+    result_.resize(players_.size());
+
+    actStates.resize(players_.size());
+    actPlayerStates.resize(players_.size());
+    actGameStates.resize(players_.size());
+    remapPlayerIdx.resize(players_.size());
+
+    basestate = std::move(game->state_);
+
+    seqs.resize(players_.size());
+
+    size_t ngames = size_t(std::max(game->perThreadBatchSize, 1));
+
+    if (game->perThreadBatchSize < 1) {
+      int bs = 10240;
+      int n = 0;
+      for (auto& v : players_) {
+        auto actorPlayer = dynamic_cast<ActorPlayer*>(v);
+        if (actorPlayer) {
+          int v = actorPlayer->findBatchSize(*basestate);
+          if (v > 0) {
+            bs = std::min(bs, v);
+            ++n;
+          }
+        }
+      }
+      if (n) {
+        fmt::printf("Using batch size of %d\n", bs);
+        ngames = bs;
+      }
+    }
 
     while (states.size() < ngames &&
-           (numEpisode < 0 || startedGameCount < numEpisode)) {
+           (game->numEpisode < 0 || startedGameCount < game->numEpisode)) {
       addGame(states.end());
     }
 
-    std::vector<std::shared_ptr<mcts::MctsPlayer>> mctsPlayers;
+    devPlayer = nullptr;
     for (auto& v : players_) {
-      auto mctsPlayer = std::dynamic_pointer_cast<mcts::MctsPlayer>(v);
-      if (!mctsPlayer) {
+      auto actorPlayer = dynamic_cast<ActorPlayer*>(v);
+      if (!actorPlayer) {
         throw std::runtime_error(
-            "Cannot use perThreadBatchSize without MctsPlayer");
+            "Cannot use perThreadBatchSize without ActorPlayer");
       }
-      mctsPlayers.push_back(std::move(mctsPlayer));
+      if (actorPlayer->getName() == "dev") {
+        devPlayer = actorPlayer;
+      }
+      actorPlayers.push_back(std::move(actorPlayer));
+      mctsPlayers.push_back(dynamic_cast<mcts::MctsPlayer*>(v));
+      forwardPlayers.push_back(dynamic_cast<ForwardPlayer*>(v));
     }
-
-    std::vector<std::vector<const mcts::State*>> actStates(players_.size());
-    std::vector<std::vector<GameState*>> actGameStates(players_.size());
-
-    bool alignPlayers = false;
+    if (!devPlayer) {
+      throw std::runtime_error("dev player not found");
+    }
 
     // If two players are the same (pointer comparison), then they can act
     // together.
-    std::vector<size_t> remapPlayerIdx(players_.size());
     for (size_t i = 0; i != players_.size(); ++i) {
       remapPlayerIdx[i] = i;
       for (size_t i2 = 0; i2 != i; ++i2) {
@@ -112,11 +791,12 @@ void Game::mainLoop() {
       }
     }
 
-    std::vector<std::pair<size_t, size_t>> statePlayerSize;
-
-    while (!states.empty() && !terminate_) {
+    while (!states.empty() && !game->terminate_) {
 
       for (auto& v : actStates) {
+        v.clear();
+      }
+      for (auto& v : actPlayerStates) {
         v.clear();
       }
       for (auto& v : actGameStates) {
@@ -125,165 +805,319 @@ void Game::mainLoop() {
 
       for (auto i = states.begin(); i != states.end();) {
         auto* state = &*i->state;
-        if (state->terminated() || i->resigned != -1) {
-          const auto end = std::chrono::system_clock::now();
+        bool completed = state->terminated() || i->resigned != -1 || i->drawn;
+        if (completed) {
+          const auto end = std::chrono::steady_clock::now();
           const auto elapsed =
               std::chrono::duration_cast<std::chrono::seconds>(end - i->start)
                   .count();
           const size_t stepindex = i->stepindex;
-          {
-            std::unique_lock<std::mutex> lkStats(mutexStats_);
-            auto& stats_steps = stats_["Game Duration (steps)"];
+          if (i->rewindCount == 0) {
+            std::unique_lock<std::mutex> lkStats(game->mutexStats_);
+            auto& stats_steps = game->stats_["Game Duration (steps)"];
             std::get<0>(stats_steps) += 1;
             std::get<1>(stats_steps) += stepindex;
             std::get<2>(stats_steps) += stepindex * stepindex;
-            auto& stats_s = stats_["Game Duration (seconds)"];
+            auto& stats_s = game->stats_["Game Duration (seconds)"];
             std::get<0>(stats_s) += 1;
             std::get<1>(stats_s) += elapsed;
             std::get<2>(stats_s) += elapsed * elapsed;
           }
+          if (i->drawn) {
+            for (size_t idx = 0; idx != players_.size(); ++idx) {
+              result_.at(i->players.at(idx)) = 0;
+            }
+          }
           if (i->resigned != -1) {
             for (size_t idx = 0; idx != players_.size(); ++idx) {
-              result_.at(idx) = int(idx) == i->resigned ? -1 : 1;
+              result_.at(i->players.at(idx)) = int(idx) == i->resigned ? -1 : 1;
             }
             // fmt::printf("player %d (%s) resigned : %s\n", i->resigned,
-            //            players_.at(i->resigned)->getName(),
+            //            players_.at(i->players.at(i->resigned))->getName(),
             //            state->history());
           } else {
             for (size_t idx = 0; idx != players_.size(); ++idx) {
-              result_[idx] = state->getReward(idx);
+              result_.at(i->players.at(idx)) = state->getReward(idx);
             }
             // fmt::printf("game ended normally: %s\n",
             // state->history().c_str());
+            if (randint(256) == 0) {
+              fmt::printf(
+                  "game ended normally: %s\n", state->history().c_str());
+            }
           }
 
-          for (size_t p = 0; p != players_.size(); ++p) {
-            // fmt::printf(
-            //    "Result for %s: %g\n", players_[p]->getName(), result_[p]);
-            for (auto& v : i->feat[p]) {
-              feature_[p].pushBack(v);
-            }
-            for (auto& v : i->pi[p]) {
-              pi_[p].pushBack(v);
-            }
-            for (auto& v : i->piMask[p]) {
-              piMask_[p].pushBack(v);
+          runningAverageGameSteps =
+              runningAverageGameSteps * 0.99f + state->getStepIdx() * 0.01f;
+        }
+
+        bool doRewind = false;
+        int rewindPlayer = 0;
+        bool rewindToNegativeValue = false;
+
+        bool isForward = dynamic_cast<ForwardPlayer*>(devPlayer) != nullptr;
+
+        int seqlen = devPlayer->rnnSeqlen();
+
+        if ((isForward && seqlen > 0) || completed) {
+          for (size_t slot = 0; slot != players_.size(); ++slot) {
+            size_t dstp = i->players.at(slot);
+
+            if (completed) {
+#ifdef OPENBW_UI
+              fmt::printf("Result for %s: %g\n", players_[dstp]->getName(),
+                          result_[dstp]);
+#endif
+            } else {
+              if ((int)i->pi[slot].size() < seqlen * 16 + 1 ||
+                  i->history.empty() || i->history.back().turn != (int)slot) {
+                continue;
+              }
+              result_[dstp] = i->history.back().value;
+
+              i->pi[slot].pop_back();
+              i->piMask[slot].pop_back();
+              i->actionPi[slot].pop_back();
+              i->predV[slot].pop_back();
+              i->feat[slot].pop_back();
+              i->rnnStates[slot].pop_back();
+              i->reward[slot].pop_back();
             }
 
-            // fmt::printf("result[%d] (%s) is %g\n", p, players_[p]->getName(),
-            // result_[p]);
-            while (v_[p].len() < pi_[p].len()) {
-              torch::Tensor reward = torch::zeros({1}, torch::kFloat32);
-              reward[0] = result_[p];
-              v_[p].pushBack(std::move(reward));
+            auto addseq = [&](const std::vector<torch::Tensor>& src,
+                              std::vector<torch::Tensor>& dst,
+                              tube::EpisodicTrajectory& traj) {
+              for (auto& x : src) {
+                dst.push_back(x);
+                if ((int)dst.size() > seqlen) {
+                  throw std::runtime_error("addseq bad seqlen");
+                }
+                if ((int)dst.size() == seqlen) {
+                  traj.pushBack(torch::stack(dst));
+                  dst.clear();
+                }
+              }
+            };
+
+            std::vector<float> dReward;
+            dReward.resize(i->feat[slot].size());
+            if (isForward) {
+              float gae = 0.0f;
+              float gamma = 0.997;
+              float gaeLambda = 0.95;
+              float reward = result_[slot];
+              // reward = 0;
+              for (size_t n = dReward.size(); n;) {
+                --n;
+                float predv = i->predV[slot].at(n).item<float>();
+                float npredv = 0.0f;
+                if (n == dReward.size() - 1) {
+                  npredv = result_[dstp];
+                  // npredv = 0;
+                } else {
+                  npredv = i->predV[slot].at(n + 1).item<float>();
+                }
+                float delta = reward + gamma * npredv - predv;
+                gae = delta + gamma * gaeLambda * gae;
+
+                dReward.at(n) = gae + predv;
+
+                reward = i->reward[slot].at(n);
+              }
+            } else {
+              float reward = result_[dstp];
+              for (size_t n = dReward.size(); n;) {
+                --n;
+                dReward.at(n) = reward;
+
+                // reward *= 0.99;
+                // reward += i->reward[slot].at(n);
+              }
             }
 
-            players_[p]->result(state, result_[p]);
+            std::vector<torch::Tensor> rewards;
+            for (size_t j = 0; j != i->feat[slot].size(); ++j) {
+              if (devPlayer->vOutputs() == 3) {
+                torch::Tensor reward = torch::zeros({3}, torch::kFloat32);
+                reward[0] = result_[dstp] > 0;
+                reward[1] = result_[dstp] < 0;
+                reward[2] = result_[dstp] == 0;
+                rewards.push_back(std::move(reward));
+              } else {
+                torch::Tensor reward = torch::zeros({1}, torch::kFloat32);
+                reward[0] = dReward.at(j);
+                rewards.push_back(std::move(reward));
+              }
+            }
+
+            std::vector<float> piReward;
+            piReward.resize(i->pi[slot].size());
+            auto& seq = seqs[dstp];
+            if (actorPlayers[dstp]->getModelId() == "dev" &&
+                i->feat[slot].size() > 0) {
+              if (seqlen) {
+                for (size_t n = 0; n != i->feat[slot].size(); ++n) {
+                  if ((seq.feat.size() + n) % seqlen == seqlen - 1) {
+                    game->rnnInitialState_[dstp].pushBack(
+                        i->rnnStates[slot].at(n));
+                  }
+                }
+                addseq(i->feat[slot], seq.feat, game->feature_[dstp]);
+                addseq(i->pi[slot], seq.pi, game->pi_[dstp]);
+                addseq(i->piMask[slot], seq.piMask, game->piMask_[dstp]);
+                if (isForward) {
+                  addseq(
+                      i->actionPi[slot], seq.actionPi, game->actionPi_[dstp]);
+                }
+                addseq(i->predV[slot], seq.predV, game->predV_[dstp]);
+                std::vector<torch::Tensor> rnnStateMask;
+                rnnStateMask.resize(i->feat[slot].size());
+                for (auto& v : rnnStateMask) {
+                  v = torch::ones({1});
+                }
+                rnnStateMask.at(0).zero_();
+                addseq(
+                    rnnStateMask, seq.rnnStateMask, game->rnnStateMask_[dstp]);
+              } else {
+                for (auto& v : i->feat[slot]) {
+                  game->feature_[dstp].pushBack(v);
+                }
+                for (auto& v : i->pi[slot]) {
+                  game->pi_[dstp].pushBack(v);
+                }
+                for (auto& v : i->piMask[slot]) {
+                  game->piMask_[dstp].pushBack(v);
+                }
+                for (auto& v : i->actionPi[slot]) {
+                  game->actionPi_[dstp].pushBack(v);
+                }
+                for (auto& v : i->predV[slot]) {
+                  game->predV_[dstp].pushBack(v);
+                }
+              }
+
+              if (game->predictEndState || game->predictNStates) {
+                int n = (game->predictEndState ? 2 : 0) + game->predictNStates;
+                auto size = state->GetRawFeatureSize();
+                size.insert(size.begin(), n);
+                auto finalsize = size;
+                finalsize[1] *= finalsize[0];
+                finalsize.erase(finalsize.begin());
+                for (size_t m = 0; m != i->history.size(); ++m) {
+                  if (!i->history[m].featurized ||
+                      i->history[m].turn != (int)slot) {
+                    continue;
+                  }
+                  auto tensor = torch::zeros(size);
+                  auto mask = torch::zeros(size);
+                  size_t offset = 0;
+                  if (game->predictEndState) {
+                    if (state->terminated()) {
+                      tensor[0].copy_(i->history.back().shortFeat);
+                      mask[0].fill_(1.0f);
+                    } else {
+                      tensor[1].copy_(i->history.back().shortFeat);
+                      mask[1].fill_(1.0f);
+                    }
+                    offset += 2;
+                  }
+                  for (int j = 0; j != game->predictNStates; ++j, ++offset) {
+                    size_t index = m + 1 + j;
+                    if (index < i->history.size()) {
+                      tensor[offset].copy_(i->history[m].shortFeat);
+                      mask[offset].fill_(1.0f);
+                    }
+                  }
+
+                  tensor = tensor.view(finalsize);
+                  mask = mask.view(finalsize);
+
+                  if (seqlen) {
+                    addseq({tensor}, seq.predictPi, game->predictPi_[dstp]);
+                    addseq(
+                        {mask}, seq.predictPiMask, game->predictPiMask_[dstp]);
+                  } else {
+                    game->predictPi_[dstp].pushBack(tensor);
+                    game->predictPiMask_[dstp].pushBack(mask);
+                  }
+                }
+              }
+
+              // fmt::printf("result[%d] (%s) is %g\n", p,
+              // players_[p]->getName(), result_[p]);
+
+              if (seqlen) {
+                addseq(rewards, seq.v, game->v_[dstp]);
+              } else {
+                for (auto& reward : rewards) {
+                  game->v_[dstp].pushBack(std::move(reward));
+                }
+              }
+            }
+
+            i->pi[slot].clear();
+            i->piMask[slot].clear();
+            i->actionPi[slot].clear();
+            i->predV[slot].clear();
+            i->feat[slot].clear();
+            i->rnnStates[slot].clear();
+            i->reward[slot].clear();
+            for (auto& v : i->history) {
+              if (v.turn == (int)slot) {
+                v.featurized = false;
+              }
+            }
+
+            if (completed) {
+              if (actorPlayers[dstp]->getModelId() == "dev") {
+                if (result_[dstp] != 0) {
+                  doRewind = true;
+                  rewindPlayer = slot;
+                  rewindToNegativeValue = result_[dstp] > 0;
+                }
+              }
+
+              if (i->rewindCount == 0 && i->validTournamentGame) {
+                actorPlayers[dstp]->result(state, result_[dstp]);
+              } else {
+                actorPlayers[dstp]->forget(state);
+              }
+            }
           }
-          sendTrajectory();
+          game->sendTrajectory();
 
+          if (doRewind) {
+            for (size_t slot = 0; slot != players_.size(); ++slot) {
+              size_t dstp = i->players.at(slot);
+              if (actorPlayers[dstp]->wantsTournamentResult()) {
+                doRewind = false;
+                break;
+              }
+            }
+          }
+        }
+
+        if (completed) {
           ++completedGameCount;
-          i = states.erase(i);
-          if (numEpisode < 0 || startedGameCount < numEpisode) {
-            i = addGame(i);
+          if (doRewind && i->rewindCount < game->maxRewinds &&
+              rewind(&*i, rewindPlayer, rewindToNegativeValue)) {
+            ++i->rewindCount;
+          } else {
+            i = states.erase(i);
+            if (game->numEpisode < 0 || startedGameCount < game->numEpisode) {
+              i = addGame(i);
+            }
           }
         } else {
           i->stepindex++;
-          auto playerIdx = state->getCurrentPlayer();
+          int slot = state->getCurrentPlayer();
+          auto playerIdx = i->players.at(slot);
           actStates.at(playerIdx).push_back(state);
+          actPlayerStates.at(playerIdx).push_back(&*i->playerState[slot]);
           actGameStates.at(playerIdx).push_back(&*i);
           ++i;
         }
       }
-
-      auto actForPlayer = [&](size_t playerIndex) {
-        // Merge all identical players so they get batched together
-        auto& states = actStates[playerIndex];
-        if (!states.empty()) {
-          statePlayerSize.clear();
-          statePlayerSize.emplace_back(playerIndex, states.size());
-          for (size_t i = 0; i != players_.size(); ++i) {
-            if (i != playerIndex && remapPlayerIdx[i] == playerIndex) {
-              auto& nstates = actStates[i];
-              if (!nstates.empty()) {
-                states.insert(states.end(), nstates.begin(), nstates.end());
-                statePlayerSize.emplace_back(i, nstates.size());
-                nstates.clear();
-              }
-            }
-          }
-          auto result = mctsPlayers.at(playerIndex)->actMcts(states);
-
-          {
-            double rps = mctsPlayers.at(playerIndex)->rolloutsPerSecond();
-            std::unique_lock<std::mutex> lkStats(mutexStats_);
-            auto& stats_s = stats_["Rollouts per second"];
-            std::get<0>(stats_s) += 1;
-            std::get<1>(stats_s) += rps;
-            std::get<2>(stats_s) += rps * rps;
-          }
-
-          // Distribute results to the correct player/state and store
-          // features for training.
-          size_t offset = 0;
-          for (size_t pi = 0; pi != statePlayerSize.size(); ++pi) {
-            size_t currentPlayerIndex = statePlayerSize[pi].first;
-            size_t currentPlayerStates = statePlayerSize[pi].second;
-            for (size_t i = 0; i != currentPlayerStates; ++i) {
-              State* state = (State*)states.at(offset + i);
-              torch::Tensor feat = getFeatureInTensor(*state);
-              auto [policy, policyMask] =
-                  getPolicyInTensor(*state, result.at(offset + i).mctsPolicy);
-
-              auto& gameState = actGameStates.at(currentPlayerIndex).at(i);
-              if (gameState->canResign) {
-                float value = result.at(offset + i).rootValue;
-                if (value < -0.95f) {
-                  if (++gameState->resignCounter.at(currentPlayerIndex) >= 7) {
-                    gameState->resigned = int(currentPlayerIndex);
-                  }
-                } else {
-                  gameState->resignCounter.at(currentPlayerIndex) = 0;
-                }
-                int opponent = (currentPlayerIndex + 1) % 2;
-                if (value > 0.95f) {
-                  ++gameState->resignCounter.at(opponent);
-                } else {
-                  gameState->resignCounter.at(opponent) = 0;
-                }
-              }
-              gameState->feat.at(currentPlayerIndex).push_back(feat);
-              gameState->pi.at(currentPlayerIndex).push_back(policy);
-              gameState->piMask.at(currentPlayerIndex).push_back(policyMask);
-
-              state->forward(result.at(offset + i).bestAction);
-
-              players_[currentPlayerIndex]->recordMove(state);
-
-              auto now = std::chrono::steady_clock::now();
-              double elapsed =
-                  std::chrono::duration_cast<
-                      std::chrono::duration<double, std::ratio<1, 1>>>(
-                      now - gameState->prevMoveTime)
-                      .count();
-              gameState->prevMoveTime = now;
-
-              {
-                std::unique_lock<std::mutex> lkStats(mutexStats_);
-                auto& stats_s = stats_["Move Duration (seconds)"];
-                std::get<0>(stats_s) += 1;
-                std::get<1>(stats_s) += elapsed;
-                std::get<2>(stats_s) += elapsed * elapsed;
-              }
-
-              // fmt::printf("game in progress: %s\n", state->history());
-            }
-            offset += currentPlayerStates;
-          }
-
-          states.clear();
-        }
-      };
 
       if (alignPlayers) {
         size_t bestPlayerIdx = 0;
@@ -302,6 +1136,32 @@ void Game::mainLoop() {
         }
       }
     }
+  }
+};
+
+void Game::mainLoop() {
+  threads::setCurrentThreadName("game thread " +
+                                std::to_string(common::getThreadId()));
+  threads::init(0);
+  if (players_.size() != (isOnePlayerGame() ? 1 : 2)) {
+    std::cout << "Error: wrong number of players: " << players_.size()
+              << std::endl;
+    assert(false);
+  }
+  if (!evalMode) {
+    reset();
+
+    for (auto& v : playerGame_) {
+      if (&*v != this && v->state_) {
+        v->state_->reset();
+      }
+    }
+
+    BatchExecutor batchExecutor;
+    batchExecutor.game = this;
+
+    batchExecutor.run();
+
   } else {
 
     // Warm up JIT/model. This can take several seconds, so do it before we
@@ -313,6 +1173,7 @@ void Game::mainLoop() {
         auto opt = mctsPlayer->option();
         mctsPlayer->option().totalTime = 0;
         mctsPlayer->option().numRolloutPerThread = 20;
+        mctsPlayer->option().randomizedRollouts = false;
         mctsPlayer->reset();
         mctsPlayer->actMcts(*state_);
         mctsPlayer->actMcts(*state_);
@@ -337,32 +1198,24 @@ void Game::mainLoop() {
 #endif
         break;
       }
-// std::unique_lock<std::mutex> lk(terminateMutex_);
 #ifdef DEBUG_GAME
       std::cout << "Thread " << thread_id << ", game " << this
                 << ": not terminating - run another iteration. " << std::endl;
 #endif
-      bool aHuman =
-          std::any_of(players_.begin(), players_.end(),
-                      [](const std::shared_ptr<mcts::Player>& player) {
-                        return player->isHuman();
-                      });
+      bool aHuman = std::any_of(players_.begin(), players_.end(),
+                                [](const std::shared_ptr<Player>& player) {
+                                  return player->isHuman();
+                                });
       if (aHuman && state_->stochasticReset()) {
         std::string line;
         std::cout << "Random outcome ?" << std::endl;
         std::cin >> line;
         state_->forcedDice = std::stoul(line, nullptr, 0);
       }
-      auto randint = [&](int n) {
-        return std::uniform_int_distribution<int>(0, n - 1)(rng_);
-      };
       reset();
       int stepindex = 0;
-      auto start = std::chrono::system_clock::now();
-      resignCounter_.resize(players_.size());
-      canResign_ = !evalMode && players_.size() == 2 && randint(6) != 0;
-      resigned_ = -1;
-      while (!state_->terminated() && resigned_ == -1) {
+      auto start = std::chrono::steady_clock::now();
+      while (!state_->terminated()) {
         stepindex += 1;
 #ifdef DEBUG_GAME
         std::cout << "Thread " << thread_id << ", game " << this << ": step "
@@ -374,8 +1227,12 @@ void Game::mainLoop() {
           state_->printLastAction();
           std::exit(0);
         }
+        if (printMoves_) {
+          std::cout << "MCTS value: " << lastMctsValue_ << "\n";
+          std::cout << "Made move: " << state_->lastMoveString() << std::endl;
+        }
       }
-      auto end = std::chrono::system_clock::now();
+      auto end = std::chrono::steady_clock::now();
       auto elapsed =
           std::chrono::duration_cast<std::chrono::seconds>(end - start).count();
       {
@@ -400,36 +1257,15 @@ void Game::mainLoop() {
         state_->printCurrentBoard();
       }
       if (std::any_of(players_.begin(), players_.end(),
-                      [](const std::shared_ptr<mcts::Player>& player) {
+                      [](const std::shared_ptr<Player>& player) {
                         return player->isTP();
                       })) {
         state_->errPrintCurrentBoard();
-      } /*else {
-        state_->printCurrentBoard();
-      }*/
-
-      if (resigned_ != -1) {
-        for (size_t idx = 0; idx != players_.size(); ++idx) {
-          result_.at(idx) = int(idx) == resigned_ ? 1 : -1;
-        }
-      } else {
-        result_[0] = state_->getReward(0);
-        if (players_.size() > 1) {
-          result_[1] = state_->getReward(1);
-        }
       }
 
-      if (!evalMode) {
-#ifdef DEBUG_GAME
-        std::cout << "Thread " << thread_id << ", game " << this
-                  << ": sending trajectory... " << std::endl;
-#endif
-        setReward(*state_, resigned_);
-        sendTrajectory();
-#ifdef DEBUG_GAME
-        std::cout << "Thread " << thread_id << ", game " << this
-                  << ": trajectory sent... " << std::endl;
-#endif
+      result_[0] = state_->getReward(0);
+      if (players_.size() > 1) {
+        result_[1] = state_->getReward(1);
       }
 
       ++gameCount;
@@ -487,6 +1323,26 @@ std::optional<int> Game::parseSpecialAction(const std::string& str) {
           std::cout << "Player " << i << " is now " << playerString(i) << "\n";
         }
         return -1;
+      } else if (str == "printmoves") {
+        printMoves_ = true;
+        return -1;
+      } else if (str == "printvalue") {
+        auto mctsPlayer = std::dynamic_pointer_cast<mcts::MctsPlayer>(
+            players_.at(state_->getCurrentPlayer()));
+        if (!mctsPlayer) {
+          for (auto& v : players_) {
+            mctsPlayer = std::dynamic_pointer_cast<mcts::MctsPlayer>(v);
+            if (mctsPlayer) {
+              break;
+            }
+          }
+        }
+        if (mctsPlayer) {
+          std::cout << "NN Value: " << mctsPlayer->calculateValue(*state_)
+                    << "\n";
+        } else {
+          std::cout << "NN Value: 0\n";
+        }
       }
       return std::nullopt;
     };
@@ -509,7 +1365,7 @@ std::optional<int> Game::parseSpecialAction(const std::string& str) {
         std::cout << "\nLast Action: " << lastAction_ << "\n\n";
       }
       std::cout << " applying action... " << std::endl;
-      auto action = *(state_->GetLegalActions().at(index).get());
+      auto action = state_->GetLegalActions().at(index);
       lastAction_ = state_->actionDescription(action);
       if (!state_->isStochastic()) {
         state_->forward(action.GetIndex());
@@ -541,7 +1397,7 @@ void Game::step() {
     // auto TPplayer = std::dynamic_pointer_cast<TPPlayer>(player);
     assert(!state_->isStochastic());
     auto index = state_->TPInputAction();
-    auto action = *(state_->GetLegalActions().at(index).get());
+    auto action = state_->GetLegalActions().at(index);
     lastAction_ = state_->actionDescription(action);
     state_->forward(index);
   } else if (player->isHuman()) {
@@ -564,7 +1420,7 @@ void Game::step() {
       return step();
     }
     std::cout << " applying action... " << std::endl;
-    auto action = *(state_->GetLegalActions().at(index).get());
+    auto action = state_->GetLegalActions().at(index);
     lastAction_ = state_->actionDescription(action);
     if (!state_->isStochastic()) {
       state_->forward(action.GetIndex());
@@ -578,14 +1434,23 @@ void Game::step() {
     }
   } else {
     auto mctsPlayer = std::dynamic_pointer_cast<mcts::MctsPlayer>(player);
-    mcts::MctsResult result = mctsPlayer->actMcts(*state_);
-    lastMctsValue_ = result.rootValue;
-
-    if (canResign_ && result.rootValue < -0.95f) {
-      if (++resignCounter_.at(playerIdx) >= 2) {
-        resigned_ = playerIdx;
+    auto rnnShape = mctsPlayer->rnnStateSize();
+    if (!rnnShape.empty()) {
+      if (rnnState_.size() <= (size_t)playerIdx) {
+        rnnState_.resize(playerIdx + 1);
+      }
+      if (!rnnState_.at(playerIdx).defined()) {
+        rnnState_[playerIdx] = torch::zeros(rnnShape);
       }
     }
+    mcts::MctsResult result;
+    if (!rnnShape.empty()) {
+      result = mctsPlayer->actMcts(*state_, rnnState_.at(playerIdx));
+      rnnState_.at(playerIdx) = std::move(result.rnnState);
+    } else {
+      result = mctsPlayer->actMcts(*state_);
+    }
+    lastMctsValue_ = result.rootValue;
 
     // store feature for training
     if (!evalMode) {
@@ -597,42 +1462,30 @@ void Game::step() {
     }
 
     // std::cout << ">>>>actual act" << std::endl;
-    _Action action = *(state_->GetLegalActions().at(result.bestAction));
+    _Action action = state_->GetLegalActions().at(result.bestAction);
     lastAction_ = state_->actionDescription(action);
-    bool noHuman =
-        std::none_of(players_.begin(), players_.end(),
-                     [](const std::shared_ptr<mcts::Player>& player) {
-                       return player->isHuman();
-                     });
+    bool noHuman = std::none_of(players_.begin(), players_.end(),
+                                [](const std::shared_ptr<Player>& player) {
+                                  return player->isHuman();
+                                });
     if (!state_->isStochastic()) {
       if (!noHuman) {
         std::cout << "Performing action "
-                  << state_->performActionDescription(
-                         *state_->GetLegalActions().at(result.bestAction))
+                  << state_->actionDescription(
+                         state_->GetLegalActions().at(result.bestAction))
                   << "\n";
       }
     } else if (!noHuman) {
       std::string line;
       std::cout << "Performing action "
-                << state_->performActionDescription(
-                       *state_->GetLegalActions().at(result.bestAction))
+                << state_->actionDescription(
+                       state_->GetLegalActions().at(result.bestAction))
                 << "\n";
       std::cout << "Random outcome ?" << std::endl;
       std::cin >> line;
       state_->forcedDice = std::stoul(line, nullptr, 0);
     }
     state_->forward(result.bestAction);
-  }
-}
-
-void Game::setReward(const State& state, int resigned) {
-  for (int i = 0; i < (int)players_.size(); ++i) {
-    assert(v_[i].len() <= pi_[i].len() && pi_[i].len() == feature_[i].len());
-    while (v_[i].len() < pi_[i].len()) {
-      torch::Tensor reward = torch::zeros({1}, torch::kFloat32);
-      reward[0] = resigned == -1 ? state.getReward(i) : i == resigned ? -1 : 1;
-      v_[i].pushBack(std::move(reward));
-    }
   }
 }
 
@@ -670,16 +1523,58 @@ void Game::sendTrajectory() {
 }
 
 bool Game::prepareForSend(int playerId) {
+  int len = feature_[playerId].len();
+#define check(n)                                                               \
+  if (!n.empty() && n[playerId].len() != len)                                  \
+  throw std::runtime_error("len mismatch in " #n)
+  check(pi_);
+  check(piMask_);
+  check(actionPi_);
+  check(v_);
+  check(predV_);
+  check(rnnInitialState_);
+  check(rnnStateMask_);
+#undef check
   if (feature_[playerId].prepareForSend()) {
-    bool sendPi = pi_[playerId].prepareForSend();
-    bool sendPiMask = piMask_[playerId].prepareForSend();
-    bool sendV = v_[playerId].prepareForSend();
-    assert(sendPi && sendV && sendPiMask);
+    bool b = pi_[playerId].prepareForSend();
+    b &= piMask_[playerId].prepareForSend();
+    if (!actionPi_.empty()) {
+      b &= actionPi_[playerId].prepareForSend();
+    }
+    b &= v_[playerId].prepareForSend();
+    b &= predV_[playerId].prepareForSend();
+    if (predictEndState + predictNStates) {
+      b &= predictPi_[playerId].prepareForSend();
+      b &= predictPiMask_[playerId].prepareForSend();
+    }
+    if (!rnnInitialState_.empty()) {
+      b &= rnnInitialState_[playerId].prepareForSend();
+      b &= rnnStateMask_[playerId].prepareForSend();
+    }
+    if (!b) {
+      throw std::runtime_error("prepareForSend mismatch 1");
+    }
     return true;
   }
-  bool sendPi = pi_[playerId].prepareForSend();
-  bool sendPiMask = piMask_[playerId].prepareForSend();
-  bool sendV = v_[playerId].prepareForSend();
-  assert((!sendPi) && (!sendV) && (!sendPiMask));
+  bool b = pi_[playerId].prepareForSend();
+  b |= piMask_[playerId].prepareForSend();
+  b |= v_[playerId].prepareForSend();
+  b |= predV_[playerId].prepareForSend();
+  if (!actionPi_.empty()) {
+    b |= actionPi_[playerId].prepareForSend();
+  }
+  if (predictEndState + predictNStates) {
+    b |= predictPi_[playerId].prepareForSend();
+    b |= predictPiMask_[playerId].prepareForSend();
+  }
+  if (!rnnInitialState_.empty()) {
+    b |= rnnInitialState_[playerId].prepareForSend();
+    b |= rnnStateMask_[playerId].prepareForSend();
+  }
+  if (b) {
+    throw std::runtime_error("prepareForSend mismatch 2");
+  }
   return false;
 }
+
+}  // namespace core

--- a/src/core/human_player.h
+++ b/src/core/human_player.h
@@ -6,10 +6,12 @@
  */
 
 #pragma once
-#include "mcts/player.h"
+#include "player.h"
 #include "state.h"
 
-class HumanPlayer : public mcts::Player {
+namespace core {
+
+class HumanPlayer : public Player {
  public:
   HumanPlayer()
       : Player(true){
@@ -22,12 +24,12 @@ class HumanPlayer : public mcts::Player {
     auto& legalActions = state.GetLegalActions();
     assert(index < (int)legalActions.size());
     std::cout << " applying action... " << std::endl;
-    return *(legalActions[index].get());
+    return legalActions[index];
     // std::cerr << " applied action... " << std::endl;
   }
 };
 
-class TPPlayer : public mcts::Player {
+class TPPlayer : public Player {
  public:
   TPPlayer()
       : Player(true) {
@@ -42,7 +44,9 @@ class TPPlayer : public mcts::Player {
     auto& legalActions = state.GetLegalActions();
     assert(index < (int)legalActions.size());
     std::cerr << " applying action... " << std::endl;
-    return *(legalActions[index].get());
+    return legalActions[index];
     // std::cerr << " applied action... " << std::endl;
   }
 };
+
+}  // namespace core

--- a/src/core/model_manager.cc
+++ b/src/core/model_manager.cc
@@ -1,33 +1,23 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
 
-#pragma once
+#include "model_manager.h"
 
-#include "data_channel.h"
-#include "distributed.h"
+#include "common/async.h"
+#include "common/thread_id.h"
+#include "distributed/distributed.h"
+#include "distributed/rpc.h"
 #include "replay_buffer.h"
+#include "tube/src_cpp/data_channel.h"
 
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
 #include <fmt/printf.h>
 #include <torch/extension.h>
 #include <torch/script.h>
 
-#include <fmt/printf.h>
-#include <torch/extension.h>
-#include <torch/script.h>
+namespace core {
 
-namespace tube {
-
-using TorchJitModel = torch::jit::script::Module;
-
-inline std::atomic_int threadIdCounter{0};
-inline thread_local int threadId = ++threadIdCounter;
-
-inline std::unordered_map<std::string, torch::Tensor> convertIValueToMap(
-    const torch::IValue& value) {
+std::unordered_map<std::string, at::Tensor> convertIValueToMap(
+    const c10::IValue& value) {
   std::unordered_map<std::string, torch::Tensor> map;
   auto dict = value.toGenericDict();
 
@@ -42,10 +32,7 @@ inline std::unordered_map<std::string, torch::Tensor> convertIValueToMap(
     torch::Tensor tensor = name2tensor.second.toTensor();
 #endif
 
-    tensor = tensor.to(torch::kCPU).detach();
-    // if (device != nullptr) {
-    //   tensor = tensor.to(device);
-    // }
+    tensor = tensor.detach();
     map.insert({name->string(), tensor});
   }
   return map;
@@ -122,8 +109,6 @@ class PriorityMutex {
   }
 };
 
-inline std::vector<PriorityMutex> mModels_(30);
-
 namespace {
 template <typename T> struct StreamBuffer : std::streambuf {
   T& buf;
@@ -177,51 +162,51 @@ template <typename T> struct StreamReadBuffer : std::streambuf {
   }
 };
 
+std::mutex deviceMutexMutex;
+std::unordered_map<std::string, PriorityMutex> deviceMutex;
+PriorityMutex* getDeviceMutex(std::string device) {
+  std::lock_guard l(deviceMutexMutex);
+  return &deviceMutex[device];
+}
+
 }  // namespace
 
-class ChannelAssembler {
+using TorchJitModel = torch::jit::script::Module;
+
+class ModelManagerImpl {
  public:
-  ChannelAssembler(int actBatchsize,
-                   int numActChannel,
-                   const std::vector<std::string>& actDevices,
+  ModelManagerImpl(int actBatchsize,
+                   const std::string& device,
                    int replayCapacity,
                    int seed,
                    const std::string& jitModel,
                    int trainChannelTimeoutMs,
                    int trainChannelNumSlots)
       : jitModel_(jitModel)
-      //, mModels_(numActChannel)
+      , device_(device)
       , replayBuffer_(replayCapacity, seed) {
-    trainChannel_ = std::make_shared<DataChannel>(
+    trainChannel_ = std::make_shared<tube::DataChannel>(
         "train", trainChannelNumSlots, trainChannelTimeoutMs);
-    assert((int)actDevices.size() >= numActChannel);
-    for (int i = 0; i < numActChannel; ++i) {
-      std::string device =
-          (size_t)i >= actDevices.size() && actDevices.size() > 0
-              ? actDevices.back()
-              : actDevices.at(i);
-      auto deviceString = torch::Device(device);
-      actDevices_.push_back(deviceString);
+    actChannel_ = std::make_shared<tube::DataChannel>("act", actBatchsize, -1);
 
 #ifdef PYTORCH12
-      models_.push_back(std::make_shared<TorchJitModel>(torch::jit::load(jitModel_)));
+    model_ =
+        std::make_shared<TorchJitModel>(torch::jit::load(jitModel_, device));
 #else
-      models_.push_back(torch::jit::load(jitModel_));
+    model_ = torch::jit::load(jitModel_, device);
 #endif
-      models_.back()->to(device);
-      models_.back()->eval();
+    model_->eval();
 
-      auto channel = std::make_shared<DataChannel>(
-          std::string("act") + std::to_string(i), actBatchsize, -1);
-      actChannels_.push_back(std::move(channel));
-    }
+    dtype_ = at::ScalarType::Float;
+
+    model_->to(dtype_);
+
+    modelMutex_ = getDeviceMutex(device);
   }
 
-  ~ChannelAssembler() {
+  ~ModelManagerImpl() {
     terminate_ = true;
-    for (auto& v : actChannels_) {
-      v->terminate();
-    }
+    actChannel_->terminate();
     trainChannel_->terminate();
     for (auto& v : threads_) {
       v.join();
@@ -232,43 +217,32 @@ class ChannelAssembler {
   }
 
   void startServer(std::string serverListenEndpoint) {
-    if (!actChannels_.empty()) {
-      throw std::runtime_error(
-          "Server should be run with no actors! (--num_game 0)");
-    }
     server_.emplace();
-    server_->onTrainData = [this](const void* data, size_t len) {
-      std::unordered_map<std::string, torch::Tensor> batch;
-      std::string_view view((const char*)data, len);
-      StreamReadBuffer<decltype(view)> buf(view);
-      while (true) {
-        auto k = buf.read();
-        auto v = buf.read();
-        if (v == std::string_view{}) {
-          break;
-        }
-        std::string str(v.data(), v.size());
-        std::istringstream is(str);
-        torch::Tensor t;
-        torch::load(t, is);
-        batch[std::string(k)] = t;
-      }
-      replayBuffer_.add(std::move(batch));
-    };
+    server_->setOnTrainData(
+        [this](std::unordered_map<std::string, torch::Tensor> batch) {
+          replayBuffer_.add(std::move(batch));
+        });
     server_->start(serverListenEndpoint);
     fmt::printf("Listening on %s\n", serverListenEndpoint);
   }
 
   void startClient(std::string serverConnectHostname) {
+    auto firstUpdate = std::make_shared<std::promise<bool>>();
+    auto firstUpdateFuture = firstUpdate->get_future();
     client_.emplace();
-    client_->onUpdateModel =
-        [this](std::string_view id,
-               std::unordered_map<std::string, torch::Tensor> dict) {
+    client_->setOnUpdateModel(
+        [this, firstUpdate](
+            std::string_view id,
+            std::unordered_map<std::string, torch::Tensor> dict) mutable {
+          if (firstUpdate) {
+            firstUpdate->set_value(true);
+            firstUpdate.reset();
+          }
           if (!dontRequestModelUpdates_) {
             fmt::printf("onUpdateModel '%s'\n", id);
             updateModel(dict);
           }
-        };
+        });
     client_->connect(serverConnectHostname);
     fmt::printf("Connected to %s\n", serverConnectHostname);
 
@@ -277,20 +251,65 @@ class ChannelAssembler {
         if (!dontRequestModelUpdates_) {
           client_->requestModel(isTournamentOpponent_);
         }
-        for (int i = 0; i != 20 && !terminate_ && !trainChannel_->terminated();
+        for (int i = 0; i != 2 && !terminate_ && !trainChannel_->terminated();
              ++i) {
           std::this_thread::sleep_for(std::chrono::seconds(2));
         }
       }
     });
+
+    if (!dontRequestModelUpdates_) {
+      fmt::printf("Waiting for model\n");
+      firstUpdateFuture.wait();
+      fmt::printf("Received model\n");
+    } else {
+      fmt::printf("Not requesting model updates\n");
+    }
   }
 
-  std::shared_ptr<DataChannel> getTrainChannel() {
+  std::unique_ptr<rpc::Rpc> replayBufferRpc;
+  std::shared_ptr<rpc::Server> replayBufferRpcServer;
+  std::shared_ptr<rpc::Client> replayBufferRpcClient;
+
+  void startReplayBufferServer(std::string endpoint) {
+    if (endpoint.substr(0, 6) == "tcp://") {
+      endpoint.erase(0, 6);
+    }
+    if (!replayBufferRpc) {
+      replayBufferRpc = std::make_unique<rpc::Rpc>();
+      replayBufferRpc->asyncRun(8);
+    }
+
+    replayBufferRpcServer = replayBufferRpc->listen("");
+    replayBufferRpcServer->define("sample", &ModelManagerImpl::sample, this);
+
+    replayBufferRpcServer->listen(endpoint);
+  }
+
+  void startReplayBufferClient(std::string endpoint) {
+    if (endpoint.substr(0, 6) == "tcp://") {
+      endpoint.erase(0, 6);
+    }
+    if (!replayBufferRpc) {
+      replayBufferRpc = std::make_unique<rpc::Rpc>();
+      replayBufferRpc->asyncRun(8);
+    }
+
+    replayBufferRpcClient = replayBufferRpc->connect(endpoint);
+  }
+
+  SampleResult remoteSample(int sampleSize) {
+    return {replayBufferRpcClient
+                ->async<std::unordered_map<std::string, torch::Tensor>>(
+                    "sample", sampleSize)};
+  }
+
+  std::shared_ptr<tube::DataChannel> getTrainChannel() {
     return trainChannel_;
   }
 
-  std::vector<std::shared_ptr<DataChannel>> getActChannels() {
-    return actChannels_;
+  std::shared_ptr<tube::DataChannel> getActChannel() {
+    return actChannel_;
   }
 
   std::unordered_map<std::string, torch::Tensor> cloneStateDict(
@@ -298,7 +317,9 @@ class ChannelAssembler {
     torch::NoGradGuard ng;
     std::unordered_map<std::string, torch::Tensor> r;
     for (auto& [name, tensor] : stateDict) {
-      r[name] = tensor.clone().detach().cpu();
+      r[name] = tensor.detach().to(
+          torch::TensorOptions().device(torch::kCPU).dtype(dtype_), false,
+          true);
     }
     return r;
   }
@@ -324,12 +345,34 @@ class ChannelAssembler {
       dst[v.name] = v.value;
     }
 
+    for (auto& [k, v] : stateDict) {
+      auto i = dst.find(k);
+      if (i == dst.end()) {
+        throw std::runtime_error(
+            fmt::sprintf("key '%s' not found in destination state dict", k));
+      } else if (i->second.sizes() != v.sizes()) {
+        throw std::runtime_error(
+            fmt::sprintf("state dict key '%s' shape mismatch", k));
+      }
+    }
+
+    for (auto& [k, v] : dst) {
+      auto i = stateDict.find(k);
+      if (i == stateDict.end()) {
+        throw std::runtime_error(
+            fmt::sprintf("key '%s' not found in source state dict", k));
+      }
+    }
+
+    fmt::printf("loadModelStateDict: state dicts OK\n");
+
     for (auto& v : stateDict) {
       auto i = dst.find(v.first);
       if (i != dst.end()) {
         dst.at(v.first).copy_(v.second).detach();
       } else {
-        fmt::printf("copyModelStateDict: Unknown state dict entry '%s'\n", v.first);
+        fmt::printf(
+            "copyModelStateDict: Unknown state dict entry '%s'\n", v.first);
         std::abort();
       }
     }
@@ -350,10 +393,10 @@ class ChannelAssembler {
           memberNameString.assign(memberNamePtr, ptr - memberNamePtr);
           subModule = currentModule->find_module(memberNameString);
           if (!subModule) {
-            fmt::printf("copyModelStateDict: Unknown state dict entry '%s' -- could "
-                   "not find module '%s'\n",
-                   name,
-                   memberNameString);
+            fmt::printf(
+                "copyModelStateDict: Unknown state dict entry '%s' -- could "
+                "not find module '%s'\n",
+                name, memberNameString);
             std::abort();
           }
           currentModule = &*subModule;
@@ -370,10 +413,10 @@ class ChannelAssembler {
       } else if (auto b = currentModule->find_buffer(memberNameString); b) {
         b->value().toTensor().copy_(tensor);
       } else {
-        fmt::printf("copyModelStateDict: Unknown state dict entry '%s' -- could not "
-               "find parameter/buffer '%s'\n",
-               name,
-               memberNameString);
+        fmt::printf(
+            "copyModelStateDict: Unknown state dict entry '%s' -- could not "
+            "find parameter/buffer '%s'\n",
+            name, memberNameString);
         std::abort();
       }
     }
@@ -388,11 +431,9 @@ class ChannelAssembler {
     if (server_) {
       server_->updateModel("dev", cloneStateDict(stateDict));
     }
-    for (size_t i = 0; i < models_.size(); ++i) {
-      PriorityMutex::setThreadPriority(-9);
-      std::lock_guard<PriorityMutex> lk(mModels_[i]);
-      loadModelStateDict(*models_[i], stateDict);
-    }
+    PriorityMutex::setThreadPriority(-9);
+    std::lock_guard<PriorityMutex> lk(*modelMutex_);
+    loadModelStateDict(*model_, stateDict);
   }
 
   int bufferSize() const {
@@ -403,45 +444,64 @@ class ChannelAssembler {
     return replayBuffer_.full();
   }
 
-  ReplayBuffer::SerializableState getBufferState() {
-    return replayBuffer_.toState();
-  }
-
-  void setBufferState(const ReplayBuffer::SerializableState& state) {
-    replayBuffer_.initFromState(state);
-  }
-
   std::unordered_map<std::string, torch::Tensor> sample(int sampleSize) {
     return replayBuffer_.sample(sampleSize);
   }
 
   void start() {
-    threads_.emplace_back(&ChannelAssembler::trainThread, this);
+    threads_.emplace_back(&ModelManagerImpl::trainThread, this);
 
-    for (int i = 0; i < (int)actChannels_.size(); ++i) {
-      threads_.emplace_back(&ChannelAssembler::actThread, this, i);
-    }
+    threads_.emplace_back(&ModelManagerImpl::actThread, this);
   }
 
   void trainThread() {
     torch::NoGradGuard ng;
     if (client_) {
+      std::atomic<bool> qdone{false};
+      int qwaiters = 0;
+      std::mutex qmut;
+      std::condition_variable qcv;
+      std::deque<std::unordered_map<std::string, torch::Tensor>> queue;
+      std::vector<std::thread> qthreads;
+      for (int i = 0; i != 4; ++i) {
+        qthreads.emplace_back([&]() {
+          while (true) {
+            std::unique_lock l(qmut);
+            ++qwaiters;
+            while (queue.empty()) {
+              if (qdone) {
+                --qwaiters;
+                return;
+              }
+              qcv.wait(l);
+            }
+            --qwaiters;
+            auto batch = std::move(queue.front());
+            queue.pop_front();
+            l.unlock();
+            client_->sendTrainData(batch);
+          }
+        });
+      }
       while (true) {
         auto batch = trainChannel_->getInput();
         if (terminate_ || trainChannel_->terminated()) {
           break;
         }
-        std::vector<char> buf;
-        StreamBuffer<decltype(buf)> obuf(buf);
-        for (auto& v : batch) {
-          obuf.write(v.first);
-          std::ostringstream stream;
-          torch::save(v.second, stream);
-          obuf.write(stream.str());
-        }
-        client_->sendTrainData(buf.data(), buf.size());
         trainChannel_->setReply({});
+        std::lock_guard l(qmut);
+        if (queue.size() < 128) {
+          queue.push_back(batch);
+        } else {
+          fmt::printf("Warning: train data queue is full, discarding data\n");
+        }
+        if (qwaiters) {
+          qcv.notify_one();
+        }
       }
+      std::lock_guard l(qmut);
+      qdone = true;
+      qcv.notify_all();
     } else {
       while (true) {
         auto batch = trainChannel_->getInput();
@@ -454,23 +514,23 @@ class ChannelAssembler {
     }
   }
 
-  void actThread(const int threadIdx) {
+  void actThread() {
     torch::NoGradGuard ng;
     while (true) {
-      auto batch = actChannels_[threadIdx]->getInput();
-      if (terminate_ || actChannels_[threadIdx]->terminated()) {
+      auto batch = actChannel_->getInput();
+      if (terminate_ || actChannel_->terminated()) {
         break;
       }
       // TODO[hengyuan]: temp hard code
-      auto s = batch["s"].to(actDevices_[threadIdx]);
+      auto s = batch["s"].to(device_);
       std::vector<torch::jit::IValue> input;
       input.push_back(s);
       PriorityMutex::setThreadPriority(-1);
-      std::unique_lock<PriorityMutex> lk(mModels_[threadIdx]);
-      auto output = models_[threadIdx]->forward(input);
+      std::unique_lock<PriorityMutex> lk(*modelMutex_);
+      auto output = model_->forward(input);
       lk.unlock();
       auto reply = convertIValueToMap(output);
-      actChannels_[threadIdx]->setReply(reply);
+      actChannel_->setReply(reply);
     }
   }
 
@@ -479,7 +539,7 @@ class ChannelAssembler {
     std::vector<torch::jit::IValue> inputs;
     auto x = torch::ones({1, 6 * 7 * 2}, torch::kFloat32);
     inputs.push_back(x);
-    auto y = models_[0]->forward(inputs);
+    auto y = model_->forward(inputs);
     auto reply = convertIValueToMap(y);
     for (auto& name2tensor : reply) {
       std::cout << name2tensor.first << ": " << std::endl;
@@ -487,29 +547,294 @@ class ChannelAssembler {
     }
   }
 
-  std::string_view batchAct(torch::Tensor input,
-                            torch::Tensor v,
-                            torch::Tensor pi) {
+  void batchAct(torch::Tensor input,
+                torch::Tensor v,
+                torch::Tensor pi,
+                torch::Tensor rnnState = {},
+                torch::Tensor* rnnStateOut = nullptr) {
     torch::NoGradGuard ng;
-    size_t n = nextActIndex_++ % models_.size();
+    bool isCuda = device_.is_cuda();
+    PriorityMutex::setThreadPriority(common::getThreadId());
+    std::optional<c10::cuda::CUDAStreamGuard> g;
+    if (isCuda) {
+      g.emplace(c10::cuda::getStreamFromPool(false, device_.index()));
+    }
     std::vector<torch::jit::IValue> inp;
-    PriorityMutex::setThreadPriority(threadId);
-    inp.push_back(input.to(actDevices_[n]));
-    std::unique_lock<PriorityMutex> lk(mModels_[n]);
-    std::string_view id = getTournamentModelId();
-    auto output = models_[n]->forward(inp);
+    inp.push_back(input.to(device_, dtype_, true));
+    if (rnnState.defined()) {
+      inp.push_back(rnnState.to(device_, dtype_, true));
+    }
+    std::unique_lock<PriorityMutex> lk(*modelMutex_);
+    auto output = model_->forward(inp);
+    if (isCuda) {
+      g->current_stream().synchronize();
+    }
     lk.unlock();
     auto reply = convertIValueToMap(output);
-    v.copy_(reply["v"]);
-    pi.copy_(reply["pi"]);
-    return id;
+    v.copy_(reply["v"], true);
+    pi.copy_(reply["pi_logit"], true);
+    if (rnnStateOut) {
+      *rnnStateOut = reply["rnn_state"];
+    }
+    if (isCuda) {
+      g->current_stream().synchronize();
+    }
   }
 
-  int bufferNumSample() const {
+  struct Timer {
+    std::chrono::steady_clock::time_point start;
+    Timer() {
+      reset();
+    }
+    void reset() {
+      start = std::chrono::steady_clock::now();
+    }
+    float elapsedAt(std::chrono::steady_clock::time_point now) {
+      return std::chrono::duration_cast<
+                 std::chrono::duration<float, std::ratio<1, 1>>>(now - start)
+          .count();
+    }
+    float elapsed() {
+      return elapsedAt(std::chrono::steady_clock::now());
+    }
+    float elapsedReset() {
+      auto now = std::chrono::steady_clock::now();
+      float r = elapsedAt(now);
+      start = now;
+      return r;
+    }
+  };
+
+  int findBatchSize(torch::Tensor input, torch::Tensor rnnState = {}) {
+    if (hasFoundBatchSize_) {
+      return foundBatchSize_;
+    }
+    torch::NoGradGuard ng;
+    bool isCuda = device_.is_cuda();
+    PriorityMutex::setThreadPriority(common::getThreadId());
+    std::optional<c10::cuda::CUDAStreamGuard> g;
+    if (isCuda) {
+      g.emplace(c10::cuda::getStreamFromPool(false, device_.index()));
+    } else {
+      return 1;
+    }
+    std::vector<torch::jit::IValue> inp;
+    torch::Tensor gpuinput = input.to(device_, dtype_, true);
+    torch::Tensor gpurnnState;
+    if (rnnState.defined()) {
+      gpurnnState = rnnState.to(device_, dtype_, true);
+    }
+    auto prep = [&](int bs) {
+      inp.clear();
+      std::vector<torch::Tensor> batch;
+      for (int i = 0; i != bs; ++i) {
+        batch.push_back(gpuinput);
+      }
+      inp.push_back(torch::stack(batch).to(device_, dtype_, true));
+      if (rnnState.defined()) {
+        batch.clear();
+        for (int i = 0; i != bs; ++i) {
+          batch.push_back(gpurnnState);
+        }
+        inp.push_back(torch::stack(batch).to(device_, dtype_, true));
+      }
+      g->current_stream().synchronize();
+    };
+    std::unique_lock<PriorityMutex> lk(*modelMutex_);
+    if (hasFoundBatchSize_) {
+      return foundBatchSize_;
+    }
+    auto call = [&]() {
+      model_->forward(inp);
+      if (isCuda) {
+        g->current_stream().synchronize();
+      }
+    };
+    fmt::printf("Finding batch size\n");
+    prep(1);
+    // warm up
+    for (int i = 0; i != 10; ++i) {
+      call();
+    }
+    Timer t;
+    for (int i = 0; i != 10; ++i) {
+      call();
+    }
+    float call1 = t.elapsed() / 10.0f * 1000.0f;
+    fmt::printf("Base latency: %gms\n", call1);
+
+    float maxms = 100.0f;
+    int maxbs = 10240;
+
+    struct I {
+      float latency = 0.0f;
+      float throughput = 0.0f;
+      int n = 0;
+      float score() {
+        return latency / n / 400 - std::log(throughput / n);
+      }
+    };
+
+    std::map<int, I> li;
+
+    int best = 0;
+    float bestScore = std::numeric_limits<float>::infinity();
+
+    auto eval = [&](int i) {
+      prep(i);
+      int badcount = 0;
+      float latency = 0.0f;
+      float throughput = 0.0f;
+      int n = 2;
+      for (int j = 0; j != n; ++j) {
+        call();
+      }
+      for (int j = 0; j != n; ++j) {
+        t.reset();
+        call();
+        float ms = t.elapsed() * 1000;
+        latency += ms;
+        throughput += i / ms;
+        if (ms > maxms || i >= maxbs) {
+          ++badcount;
+        }
+      }
+      auto& x = li[i];
+      x.latency += latency;
+      x.throughput += throughput;
+      x.n += n;
+      float score = x.score();
+      if (badcount < n && score < bestScore) {
+        bestScore = score;
+        best = i;
+      }
+      return badcount < n;
+    };
+
+    for (int i = 1;; i += (i + 1) / 2) {
+      if (!eval(i)) {
+        break;
+      }
+    }
+    std::minstd_rand rng(std::random_device{}());
+
+    auto expandNear = [&](int k) {
+      int r = 0;
+      auto i = li.find(k);
+      if (i != li.end()) {
+        auto search = [&](auto begin, auto end) {
+          int b = begin->first;
+          int e;
+          if (end == li.end()) {
+            e = std::prev(end)->first;
+          } else {
+            e = end->first;
+          }
+          b = std::max(b, i->first - 3);
+          e = std::max(b, i->first + 6);
+          for (int i = b; i != e; ++i) {
+            if (li.find(i) != li.end()) {
+              continue;
+            }
+            ++r;
+            if (!eval(i)) {
+              break;
+            }
+          }
+        };
+        search(i, std::next(i));
+        if (i != li.begin()) {
+          search(std::prev(i), i);
+        }
+      }
+      return r;
+    };
+
+    for (int j = 0; j != 4; ++j) {
+      int expands = 12;
+      for (int k = 0; k != 12; ++k) {
+        float sum = 0.0f;
+        std::vector<std::tuple<float, int, int>> list;
+        float minweight = std::numeric_limits<float>::infinity();
+        for (auto& [k, v] : li) {
+          minweight = std::min(minweight, v.score());
+        }
+        for (auto i = li.begin();;) {
+          auto next = std::next(i);
+          if (next == li.end()) {
+            break;
+          }
+          int from = i->first + 1;
+          int to = next->first;
+          if (to - from > 0) {
+            float weight =
+                std::min(i->second.score(), next->second.score()) - minweight;
+            weight = 1.0f / std::min(std::exp(weight * 4), 1e9f);
+            weight *= to - from;
+            list.emplace_back(weight, from, to);
+            sum += weight;
+          }
+          i = next;
+        }
+        if (list.size() > 0 && sum > 0.0f) {
+          float val = std::uniform_real_distribution<float>(0.0f, sum)(rng);
+          for (auto& [weight, from, to] : list) {
+            val -= weight;
+            if (val <= 0) {
+              int k = std::uniform_int_distribution<int>(from, to - 1)(rng);
+              eval(k);
+              if (expands > 0) {
+                expands -= expandNear(k);
+              }
+              break;
+            }
+          }
+        }
+      }
+      if (best) {
+        expandNear(best);
+      }
+      std::vector<std::tuple<float, int>> sorted;
+      for (auto& [k, v] : li) {
+        sorted.emplace_back(v.score(), k);
+      }
+      std::sort(sorted.begin(), sorted.end());
+      for (size_t i = 0; i != sorted.size() && i < 10; ++i) {
+        int k = std::get<1>(sorted[i]);
+        if (li[k].n < 8) {
+          eval(k);
+        }
+      }
+    }
+    foundBatchSize_ = best;
+    hasFoundBatchSize_ = true;
+
+    for (auto& [k, v] : li) {
+      fmt::printf(
+          "Batch size %d, evals %d latency %fms throughput %g score %g\n", k,
+          v.n, v.latency / v.n, v.throughput / v.n, v.score());
+    }
+
+    fmt::printf("Found best batch size of %d with evals %d latency %fms "
+                "throughput %g score %g\n",
+                best, li[best].n, li[best].latency / li[best].n,
+                li[best].throughput / li[best].n, li[best].score());
+    return best;
+  }
+
+  bool isCuda() const {
+    return device_.is_cuda();
+  }
+
+  torch::Device device() const {
+    return device_;
+  }
+
+  int64_t bufferNumSample() const {
     return replayBuffer_.numSample();
   }
 
-  int bufferNumAdd() const {
+  int64_t bufferNumAdd() const {
     return replayBuffer_.numAdd();
   }
 
@@ -521,6 +846,10 @@ class ChannelAssembler {
   }
   void setDontRequestModelUpdates(bool v) {
     dontRequestModelUpdates_ = v;
+  }
+
+  bool wantsTournamentResult() {
+    return client_ ? client_->wantsTournamentResult() : false;
   }
 
   std::string_view getTournamentModelId() {
@@ -540,24 +869,159 @@ class ChannelAssembler {
 
  private:
   const std::string jitModel_;
-  std::vector<torch::Device> actDevices_;
+  torch::Device device_;
+  torch::ScalarType dtype_;
 
-  // std::vector<PriorityMutex> mModels_;
-  std::vector<std::shared_ptr<TorchJitModel>> models_;
-  std::vector<std::shared_ptr<DataChannel>> actChannels_;
-  std::shared_ptr<DataChannel> trainChannel_;
+  PriorityMutex* modelMutex_;
+  std::shared_ptr<TorchJitModel> model_;
+  std::shared_ptr<tube::DataChannel> actChannel_;
+  std::shared_ptr<tube::DataChannel> trainChannel_;
   std::vector<std::thread> threads_;
   std::atomic_bool terminate_{false};
 
   ReplayBuffer replayBuffer_;
 
   std::atomic_size_t nextActIndex_{0};
-  std::optional<DistributedServer> server_;
-  std::optional<DistributedClient> client_;
+  std::optional<distributed::Server> server_;
+  std::optional<distributed::Client> client_;
   std::thread modelUpdateThread;
   bool isTournamentOpponent_ = false;
   bool dontRequestModelUpdates_ = false;
-  int clientModelVersion_ = -1;
+
+  std::atomic<bool> hasFoundBatchSize_ = false;
+  std::atomic<int> foundBatchSize_ = 0;
 };
 
-}  // namespace tube
+ModelManager::ModelManager() {
+}
+
+ModelManager::ModelManager(int actBatchsize,
+                           const std::string& device,
+                           int replayCapacity,
+                           int seed,
+                           const std::string& jitModel,
+                           int trainChannelTimeoutMs,
+                           int trainChannelNumSlots) {
+  impl = std::make_unique<ModelManagerImpl>(
+      actBatchsize, device, replayCapacity, seed, jitModel,
+      trainChannelTimeoutMs, trainChannelNumSlots);
+}
+
+ModelManager::~ModelManager() {
+}
+
+std::shared_ptr<tube::DataChannel> ModelManager::getTrainChannel() {
+  return impl->getTrainChannel();
+}
+
+std::shared_ptr<tube::DataChannel> ModelManager::getActChannel() {
+  return impl->getActChannel();
+}
+
+void ModelManager::updateModel(
+    const std::unordered_map<std::string, at::Tensor>& stateDict) {
+  return impl->updateModel(stateDict);
+}
+
+int ModelManager::bufferSize() const {
+  return impl->bufferSize();
+}
+
+bool ModelManager::bufferFull() const {
+  return impl->bufferFull();
+}
+
+std::unordered_map<std::string, at::Tensor> ModelManager::sample(
+    int sampleSize) {
+  return impl->sample(sampleSize);
+}
+
+void ModelManager::start() {
+  return impl->start();
+}
+
+void ModelManager::testAct() {
+  return impl->testAct();
+}
+
+void ModelManager::setIsTournamentOpponent(bool mode) {
+  return impl->setIsTournamentOpponent(mode);
+}
+
+void ModelManager::addTournamentModel(
+    std::string id,
+    const std::unordered_map<std::string, at::Tensor>& stateDict) {
+  return impl->addTournamentModel(std::move(id), stateDict);
+}
+
+void ModelManager::setDontRequestModelUpdates(bool v) {
+  return impl->setDontRequestModelUpdates(v);
+}
+
+void ModelManager::startServer(std::string serverListenEndpoint) {
+  return impl->startServer(serverListenEndpoint);
+}
+
+void ModelManager::startClient(std::string serverConnectHostname) {
+  return impl->startClient(serverConnectHostname);
+}
+
+void ModelManager::startReplayBufferServer(std::string endpoint) {
+  return impl->startReplayBufferServer(endpoint);
+}
+
+void ModelManager::startReplayBufferClient(std::string endpoint) {
+  return impl->startReplayBufferClient(endpoint);
+}
+
+SampleResult ModelManager::remoteSample(int sampleSize) {
+  return impl->remoteSample(sampleSize);
+}
+
+bool ModelManager::isCuda() const {
+  return impl->isCuda();
+}
+
+torch::Device ModelManager::device() const {
+  return impl->device();
+}
+
+void ModelManager::batchAct(at::Tensor input,
+                            at::Tensor v,
+                            at::Tensor pi,
+                            at::Tensor rnnState,
+                            at::Tensor* rnnStateOut) {
+  return impl->batchAct(std::move(input), std::move(v), std::move(pi),
+                        std::move(rnnState), rnnStateOut);
+}
+
+std::string_view ModelManager::getTournamentModelId() {
+  return impl->getTournamentModelId();
+}
+
+void ModelManager::result(float reward,
+                          std::unordered_map<std::string_view, float> models) {
+  return impl->result(reward, std::move(models));
+}
+
+int ModelManager::findBatchSize(at::Tensor input, at::Tensor rnnState) {
+  return impl->findBatchSize(input, rnnState);
+}
+
+int64_t ModelManager::bufferNumSample() const {
+  return impl->bufferNumSample();
+}
+
+int64_t ModelManager::bufferNumAdd() const {
+  return impl->bufferNumAdd();
+}
+
+bool ModelManager::isTournamentOpponent() const {
+  return impl->isTournamentOpponent();
+}
+
+bool ModelManager::wantsTournamentResult() {
+  return impl->wantsTournamentResult();
+}
+
+}  // namespace core

--- a/src/core/model_manager.h
+++ b/src/core/model_manager.h
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <tube/src_cpp/data_channel.h>
+
+#include <future>
+#include <memory>
+#include <string>
+#include <torch/torch.h>
+#include <unordered_map>
+
+namespace core {
+
+struct SampleResult {
+  std::future<std::unordered_map<std::string, torch::Tensor>> fut;
+
+  std::unordered_map<std::string, torch::Tensor> get() {
+    return fut.get();
+  }
+};
+
+class ModelManagerImpl;
+class ModelManager {
+  std::unique_ptr<ModelManagerImpl> impl;
+
+ public:
+  ModelManager();
+  ModelManager(int actBatchsize,
+               const std::string& device,
+               int replayCapacity,
+               int seed,
+               const std::string& jitModel,
+               int trainChannelTimeoutMs,
+               int trainChannelNumSlots);
+  ~ModelManager();
+
+  std::shared_ptr<tube::DataChannel> getTrainChannel();
+  std::shared_ptr<tube::DataChannel> getActChannel();
+  void updateModel(
+      const std::unordered_map<std::string, torch::Tensor>& stateDict);
+  int bufferSize() const;
+  bool bufferFull() const;
+  std::unordered_map<std::string, torch::Tensor> sample(int sampleSize);
+  void start();
+  void testAct();
+  void setIsTournamentOpponent(bool mode);
+  void addTournamentModel(
+      std::string id,
+      const std::unordered_map<std::string, torch::Tensor>& stateDict);
+  void setDontRequestModelUpdates(bool v);
+  void startServer(std::string serverListenEndpoint);
+  void startClient(std::string serverConnectHostname);
+  void startReplayBufferServer(std::string endpoint);
+  void startReplayBufferClient(std::string endpoint);
+  SampleResult remoteSample(int sampleSize);
+
+  bool isCuda() const;
+  torch::Device device() const;
+  void batchAct(torch::Tensor input,
+                torch::Tensor v,
+                torch::Tensor pi,
+                torch::Tensor rnnState = {},
+                torch::Tensor* rnnStateOut = nullptr);
+  std::string_view getTournamentModelId();
+  void result(float reward, std::unordered_map<std::string_view, float> models);
+  int findBatchSize(torch::Tensor input, torch::Tensor rnnState = {});
+  int64_t bufferNumSample() const;
+  int64_t bufferNumAdd() const;
+  bool isTournamentOpponent() const;
+  bool wantsTournamentResult();
+};
+
+}  // namespace core

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace core {
+
+class State;
+class Player {
+ public:
+  Player(bool isHuman)
+      : isHuman_(isHuman) {
+    isTP_ = false;
+  }
+
+  bool isHuman() const {
+    return isHuman_;
+  }
+  bool isTP() const {
+    return isTP_;
+  }
+
+  virtual void setName(std::string name) {
+    name_ = std::move(name);
+  }
+  const std::string& getName() {
+    return name_;
+  }
+
+  virtual void terminate() {
+  }
+  virtual void reset() {
+  }
+
+ private:
+  std::string name_ = "unnamed";
+  bool isHuman_;
+
+ protected:
+  bool isTP_;
+};
+
+}  // namespace core

--- a/src/core/pybind.cc
+++ b/src/core/pybind.cc
@@ -8,39 +8,81 @@
 #include <pybind11/pybind11.h>
 
 #include "actor.h"
+#include "common/threads.h"
+#include "forward_player.h"
 #include "game.h"
-#include "tube/src_cpp/channel_assembler.h"
+#include "model_manager.h"
 
 namespace py = pybind11;
 
+using namespace core;
+
 PYBIND11_MODULE(polygames, m) {
 
+  m.def("init_threads", &threads::init);
+
   py::class_<Game, tube::EnvThread, std::shared_ptr<Game>>(m, "Game")
-      //      .def(py::init<std::string, int, int, bool>())
-      .def(py::init<std::string, int, int, bool, bool, bool, bool, int, int,
-                    bool, int>())
+      .def(py::init<std::string, int, int, bool, bool, bool, bool, bool, int,
+                    int, bool, int, int, bool, int>())
       .def("add_player", &Game::addPlayer, py::keep_alive<1, 2>())
       .def("add_eval_player", &Game::addEvalPlayer)
       .def("add_human_player", &Game::addHumanPlayer)
       .def("add_tp_player", &Game::addTPPlayer)
-      .def("get_feat_size", &Game::getFeatSize)
       .def("get_raw_feat_size", &Game::getRawFeatSize)
+      .def("get_feat_size", &Game::getFeatSize)
       .def("is_one_player_game", &Game::isOnePlayerGame)
       .def("set_features", &Game::setFeatures)
       .def("get_action_size", &Game::getActionSize)
       .def("get_result", &Game::getResult);
 
-  py::class_<Actor, mcts::Actor, std::shared_ptr<Actor>>(m, "Actor")
+  py::class_<Actor, std::shared_ptr<Actor>>(m, "Actor")
       .def(py::init<std::shared_ptr<tube::DataChannel>,
                     const std::vector<int64_t>&,  // featSize
                     const std::vector<int64_t>&,  // actionSize
+                    const std::vector<int64_t>&,  // rnnStateSize
+                    int,                          // rnnSeqlen
+                    bool,                         // logitValue
                     bool,                         // useValue
                     bool,                         // usePolicy
-                    std::shared_ptr<tube::ChannelAssembler>>());
+                    std::shared_ptr<ModelManager>>());
 
   py::class_<HumanPlayer, std::shared_ptr<HumanPlayer>>(m, "HumanPlayer")
       .def(py::init<>(), py::call_guard<py::gil_scoped_release>());
 
   py::class_<TPPlayer, std::shared_ptr<TPPlayer>>(m, "TPPlayer")
       .def(py::init<>(), py::call_guard<py::gil_scoped_release>());
+
+  py::class_<ActorPlayer, std::shared_ptr<ActorPlayer>>(m, "ActorPlayer")
+      .def(py::init<>(), py::call_guard<py::gil_scoped_release>())
+      .def("set_actor", &ForwardPlayer::setActor, py::keep_alive<1, 2>())
+      .def("set_name", &ForwardPlayer::setName);
+
+  py::class_<ForwardPlayer, ActorPlayer, std::shared_ptr<ForwardPlayer>>(
+      m, "ForwardPlayer")
+      .def(py::init<>(), py::call_guard<py::gil_scoped_release>());
+
+  py::class_<ModelManager, std::shared_ptr<ModelManager>>(m, "ModelManager")
+      .def(py::init<int, const std::string&, int, int, const std::string&, int,
+                    int>())
+      .def("get_train_channel", &ModelManager::getTrainChannel)
+      .def("get_act_channel", &ModelManager::getActChannel)
+      .def("update_model", &ModelManager::updateModel)
+      .def("buffer_size", &ModelManager::bufferSize)
+      .def("buffer_full", &ModelManager::bufferFull)
+      .def("buffer_num_sample", &ModelManager::bufferNumSample)
+      .def("buffer_num_add", &ModelManager::bufferNumAdd)
+      .def("sample", &ModelManager::sample)
+      .def("start", &ModelManager::start)
+      .def("test_act", &ModelManager::testAct)
+      .def("set_is_tournament_opponent", &ModelManager::setIsTournamentOpponent)
+      .def("add_tournament_model", &ModelManager::addTournamentModel)
+      .def("set_dont_request_model_updates",
+           &ModelManager::setDontRequestModelUpdates)
+      .def("start_server", &ModelManager::startServer)
+      .def("start_client", &ModelManager::startClient)
+      .def("start_replay_buffer_server", &ModelManager::startReplayBufferServer)
+      .def("start_replay_buffer_client", &ModelManager::startReplayBufferClient)
+      .def("remote_sample", &ModelManager::remoteSample);
+
+  py::class_<SampleResult>(m, "SampleResult").def("get", &SampleResult::get);
 }

--- a/src/core/replay_buffer.h
+++ b/src/core/replay_buffer.h
@@ -9,26 +9,17 @@
 
 #include <mutex>
 #include <random>
+#include <string>
+#include <torch/torch.h>
+#include <unordered_map>
 #include <vector>
 
-#include "data_block.h"
-
-namespace tube {
+namespace core {
 
 class ReplayBuffer {
  public:
-  struct SerializableState {
-    int capacity;
-    int size;
-    int nextIdx;
-    std::string rngState;
-    std::unordered_map<std::string, torch::Tensor> buffer;
-  };
-
-  ReplayBuffer(int capacity, int seed)
-      : capacity(capacity) {
-    rng_.seed(seed);
-  }
+  ReplayBuffer(int capacity, int seed);
+  ~ReplayBuffer();
 
   /*
    * add to the circular array the elements of input
@@ -37,17 +28,38 @@ class ReplayBuffer {
    */
   void add(std::unordered_map<std::string, torch::Tensor> input);
 
+  template <typename T> static std::string ss(T&& sizes) {
+    std::string r = "[";
+    for (int64_t v : sizes) {
+      if (r != "[")
+        r += ", ";
+      r += std::to_string(v);
+    }
+    return r + "]";
+  }
+
   /*
    * sample sampleSize elements from the replayBuffer
    */
+  std::unordered_map<std::string, torch::Tensor> sampleImpl(int sampleSize);
+
+  std::mutex mut;
+  std::condition_variable cv;
+  std::condition_variable cv2;
+  std::deque<std::unordered_map<std::string, torch::Tensor>> results;
+  int resultsSampleSize = 0;
+  bool sampleThreadDie = false;
+
+  std::vector<std::thread> sampleThreads;
+
   std::unordered_map<std::string, torch::Tensor> sample(int sampleSize);
 
   int size() const {
-    return size_;
+    return (int)std::min((int64_t)numAdd_, (int64_t)capacity);
   }
 
   bool full() const {
-    return size_ == capacity;
+    return size() == capacity;
   }
 
   int64_t numAdd() const {
@@ -58,40 +70,34 @@ class ReplayBuffer {
     return numSample_;
   }
 
-  /*
-   * Convert replay buffer to a serializable state (thread-safe)
-   */
-  SerializableState toState();
-
-  /*
-   * Restore replay buffer from a serializable state
-   */
-  void initFromState(const SerializableState& state);
-
   const int capacity;
 
  private:
-  /*
-   * given an input to the replay buffer, calculate the indices of buffer_ to
-   * copy the input.
-   * At the same time, we verify that the sizes of each tensor in input are the
-   * same and that
-   * the input is no larger than than the capacity of the buffer.
-   */
-  torch::Tensor getNextIndices(
-      std::unordered_map<std::string, torch::Tensor>& input);
+  struct Key {
+    std::string name;
+    std::vector<int64_t> shape;
+    caffe2::TypeMeta dtype;
+  };
 
-  // mutex for buffer_
-  std::mutex mBuf_;
-  // the actual circular replay buffer
-  std::unordered_map<std::string, torch::Tensor> buffer_;
-  // how many items in buffer
-  int size_ = 0;
-  // the next index to write to
-  int nextIdx_ = 0;
-  int64_t numAdd_ = 0;
-  int64_t numSample_ = 0;
+  struct BufferEntry {
+    size_t datasize;
+    std::vector<char> data;
+  };
+
+  std::vector<std::atomic<BufferEntry*>> buffer;
+
+  size_t sampleOrderIndex = 0;
+  std::vector<size_t> sampleOrder;
+
+  std::vector<Key> keys;
+  std::mutex keyMutex;
+  std::atomic<bool> hasKeys = false;
+  std::mutex sampleMutex;
+  int64_t prevSampleNumAdd_ = 0;
+  std::atomic_int64_t numAdd_ = 0;
+  std::atomic_int64_t numSample_ = 0;
 
   std::mt19937 rng_;
 };
-}  // namespace tube
+
+}  // namespace core

--- a/src/core/test_state.cc
+++ b/src/core/test_state.cc
@@ -9,7 +9,7 @@
 #include "state.h"
 #include <iostream>
 
-float goodEval(State& s) {
+float goodEval(core::State& s) {
   float numWins = 0;
   int gameCount = 0;
   while (gameCount < 100) {
@@ -29,7 +29,7 @@ float goodEval(State& s) {
   return true;
 }
 
-float randEval(State& s) {
+float randEval(core::State& s) {
   float numWins = 0;
   int gameCount = 0;
   while (gameCount < 100) {
@@ -49,7 +49,7 @@ float randEval(State& s) {
   return true;
 }
 
-int doSimpleTest(State& s) {
+int doSimpleTest(core::State& s) {
   // goodEval(s);
   // Test that everything is fine.
   // win_frequency = 0 or 1 in purely random play is weird.
@@ -115,12 +115,14 @@ int doSimpleTest(State& s) {
   return s.GetFeatureSize()[0];
 }
 
-void doTest(State& s) {
+void doTest(core::State& s) {
   doSimpleTest(s);
   std::cout << "testing: fillFullFeatures at the end of ApplyAction and of "
                "Initialize."
             << std::endl;
-  s.setFeatures(false, false, false, 0, 3, false);
+  core::FeatureOptions opt;
+  opt.randomFeatures = 3;
+  s.setFeatures(&opt);
   doSimpleTest(s);
 }
 
@@ -415,5 +417,12 @@ int main() {
     auto state = StateForKyotoshogi(seed);
     doTest(state);
     std::cout << "test pass: Kyotoshogi" << std::endl;
+  }
+
+  {
+    std::cout << "testing: chess" << std::endl;
+    auto state = chess::State(seed);
+    doTest(state);
+    std::cout << "test pass: chess" << std::endl;
   }
 }

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -11,6 +11,8 @@
 
 #include "state.h"
 
+namespace core {
+
 inline void getFeatureInTensor(const State& state, float* dest) {
   auto& feat = state.GetFeatures();
   memcpy(dest, feat.data(), sizeof(float) * feat.size());
@@ -21,6 +23,9 @@ inline void getFeatureInTensor(const State& state, torch::Tensor dest) {
   auto& feat = state.GetFeatures();
   torch::Tensor temp = torch::from_blob(
       (void*)feat.data(), state.GetFeatureSize(), dest.dtype());
+  if (feat.size() != temp.numel()) {
+    throw std::runtime_error("getFeatureInTensor size mismatch");
+  }
   dest.copy_(temp);
 }
 
@@ -30,8 +35,44 @@ inline torch::Tensor getFeatureInTensor(const State& state) {
   return t;
 }
 
+inline void getRawFeatureInTensor(const State& state, torch::Tensor dest) {
+  assert(dest.dtype() == torch::kFloat32);
+  auto& feat = state.GetRawFeatures();
+  torch::Tensor temp = torch::from_blob(
+      (void*)feat.data(), state.GetRawFeatureSize(), dest.dtype());
+  if (feat.size() != temp.numel()) {
+    throw std::runtime_error("getRawFeatureInTensor size mismatch");
+  }
+  dest.copy_(temp);
+}
+
+inline torch::Tensor getRawFeatureInTensor(const State& state) {
+  torch::Tensor t = torch::zeros(state.GetRawFeatureSize(), torch::kFloat32);
+  getRawFeatureInTensor(state, t);
+  return t;
+}
+
+inline void getPolicyMaskInTensor(
+    const State& state, torch::TensorAccessor<float, 3> maskaccessor) {
+  for (const auto& action : state.GetLegalActions()) {
+    maskaccessor[action.GetX()][action.GetY()][action.GetZ()] = 1;
+  }
+}
+
+inline void getPolicyMaskInTensor(const State& state, torch::Tensor& mask) {
+  assert(state.GetActionSize().size() == 3);
+  auto maskaccessor = mask.accessor<float, 3>();
+  getPolicyMaskInTensor(state, maskaccessor);
+}
+
+inline torch::Tensor getPolicyMaskInTensor(const State& state) {
+  torch::Tensor mask = torch::zeros(state.GetActionSize(), torch::kFloat32);
+  getPolicyMaskInTensor(state, mask);
+  return mask;
+}
+
 inline void getPolicyInTensor(const State& state,
-                              const std::unordered_map<mcts::Action, float>& pi,
+                              const std::vector<float>& pi,
                               torch::Tensor& dest,
                               torch::Tensor& mask) {
   assert(dest.dtype() == torch::kFloat32);
@@ -40,77 +81,85 @@ inline void getPolicyInTensor(const State& state,
   auto maskaccessor = mask.accessor<float, 3>();
 
   const auto& legalAction = state.GetLegalActions();
-  for (const auto& a2pi : pi) {
-    mcts::Action actionIdx = a2pi.first;
+  for (mcts::Action actionIdx = 0; actionIdx != pi.size(); ++actionIdx) {
     if (actionIdx >= (int)legalAction.size() || actionIdx < 0) {
-      std::terminate();
       std::cout << "Wrong action in getPolicyTargetInTensor, "
                 << "action idx: " << actionIdx
                 << ", num legal: " << legalAction.size() << std::endl;
+      std::terminate();
       assert(false);
     }
     const auto& action = legalAction[actionIdx];
-    float pi = a2pi.second;
-    // std::cout << "action: " << action << ", pi: " << pi << std::endl;
-    accessor[action->GetX()][action->GetY()][action->GetZ()] = pi;
-    maskaccessor[action->GetX()][action->GetY()][action->GetZ()] = 1;
+    float piVal = pi[actionIdx];
+    int x = action.GetX();
+    int y = action.GetY();
+    int z = action.GetZ();
+    accessor[x][y][z] += piVal;
+    maskaccessor[x][y][z] = 1;
   }
 }
 
 inline std::pair<torch::Tensor, torch::Tensor> getPolicyInTensor(
-    const State& state, const std::unordered_map<mcts::Action, float>& pi) {
+    const State& state, const std::vector<float>& pi) {
   torch::Tensor t = torch::zeros(state.GetActionSize(), torch::kFloat32);
   torch::Tensor mask = torch::zeros(state.GetActionSize(), torch::kFloat32);
   getPolicyInTensor(state, pi, t, mask);
   return std::make_pair(t, mask);
 }
 
-inline void normalize(std::unordered_map<mcts::Action, float>& a2pi) {
+inline void normalize(std::vector<float>& a2pi) {
   float sumProb = 0.0f;
-  for (const auto& p : a2pi) {
-    sumProb += p.second;
+  for (auto& p : a2pi) {
+    sumProb += p;
+  }
+
+  if (sumProb > 1.0f + 1e-3f) {
+    throw std::runtime_error("sumProb is " + std::to_string(sumProb));
   }
 
   if (sumProb != 0.0f) {
     for (auto& p : a2pi) {
-      p.second /= sumProb;
+      p /= sumProb;
     }
   }
 }
 
-inline std::unordered_map<mcts::Action, float> getLegalPi(
-    const State& state, torch::TensorAccessor<float, 3> accessor) {
-  std::unordered_map<mcts::Action, float> a2pi;
+inline void getLegalPi(const State& state,
+                       torch::TensorAccessor<float, 3> accessor,
+                       std::vector<float>& out) {
   const auto& legalActions = state.GetLegalActions();
-  auto as = state.GetActionSize();
-  for (const auto& action : legalActions) {
-    if ((action->GetX() >= as[0]) || (action->GetY() >= as[1]) ||
-        (action->GetZ() >= as[2])) {
-      std::cout << action->GetX() << "," << action->GetY() << ","
-                << action->GetZ() << " / " << as[0] << "," << as[1] << ","
-                << as[2] << std::endl;
-    }
-    assert(action->GetX() < as[0]);
-    assert(action->GetY() < as[1]);
-    assert(action->GetZ() < as[2]);
-    float pi = accessor[action->GetX()][action->GetY()][action->GetZ()];
-    auto it = a2pi.insert({action->GetIndex(), pi});
-    assert(it.second == true);
+  out.resize(legalActions.size());
+  for (size_t i = 0; i != legalActions.size(); ++i) {
+    const auto& action = legalActions[i];
+    float& pi = accessor[action.GetX()][action.GetY()][action.GetZ()];
+    out[i] = std::exchange(pi, -400.0f);
+    // we exchange with -400 (exp(-400) ~ 0) because:
+    //  - two actions A and B can share the same policy output location
+    //  - the NN will then be trained to output the sum of their policy values
+    //  in that location
+    //  - if we give both actions that policy output, there will be a bias in
+    //  the MCTS towards exploring
+    //     A and B, and the sum of all policy values will be > 1
+    //  - instead, we give the sum to one action and 0 to the others, preserving
+    //  the sum of probabilities
+    //  - the MCTS must compensate for this by forcefully visiting both A and B
+    //  whenever A or B is visited
+    //      other algorithms are unlikely to support multiple actions sharing
+    //      the same policy output
+    //  - it would be equivalent to divide pi by the number of actions that
+    //  share this policy value (2 in
+    //      this case), but it would be slower as we don't know beforehand how
+    //      many that is
+    // this will set the source tensor to all -400 (it shouldn't be needed for
+    // anything else)
   }
-  normalize(a2pi);
-  return a2pi;
 }
 
-inline std::unordered_map<mcts::Action, float> getLegalPi(
-    const State& state, const torch::Tensor& pi) {
-  // assert pi is prob not logit
-  // std::cout << pi.sum().item<float>() << std::endl;
-  float pi_sum = pi.sum().item<float>();
-  assert(std::abs(pi_sum - 1) < 1e-2);
-  assert(pi.min().item<float>() >= (float)0);
-
+inline void getLegalPi(const State& state,
+                       const torch::Tensor& pi,
+                       std::vector<float>& out) {
   auto accessor = pi.accessor<float, 3>();
-  return getLegalPi(state, accessor);
+  return getLegalPi(state, accessor, out);
 }
 
 inline int64_t product(const std::vector<int64_t>& nums) {
@@ -120,3 +169,54 @@ inline int64_t product(const std::vector<int64_t>& nums) {
   }
   return p;
 }
+
+template <typename T> inline static void softmax_(T begin, T end) {
+  if (begin == end) {
+    return;
+  }
+  float max = *begin;
+  for (auto i = std::next(begin); i != end; ++i) {
+    max = std::max(max, *i);
+  }
+  float sum = 0.0f;
+  for (auto i = begin; i != end; ++i) {
+    *i = std::exp(*i - max);
+    sum += *i;
+  }
+  for (auto i = begin; i != end; ++i) {
+    *i /= sum;
+  }
+}
+
+inline static void softmax_(std::vector<float>& vec) {
+  softmax_(vec.begin(), vec.end());
+}
+
+template <typename T>
+inline static void softmax_(T begin, T end, float temperature) {
+  if (begin == end) {
+    return;
+  }
+  float itemp = 1.0f / temperature;
+  for (auto i = begin; i != end; ++i) {
+    *i *= itemp;
+  }
+  float max = *begin;
+  for (auto i = std::next(begin); i != end; ++i) {
+    max = std::max(max, *i);
+  }
+  float sum = 0.0f;
+  for (auto i = begin; i != end; ++i) {
+    *i = std::exp(*i - max);
+    sum += *i;
+  }
+  for (auto i = begin; i != end; ++i) {
+    *i /= sum;
+  }
+}
+
+inline static void softmax_(std::vector<float>& vec, float temperature) {
+  softmax_(vec.begin(), vec.end(), temperature);
+}
+
+}  // namespace core


### PR DESCRIPTION
A lot of code has moved to core from being poorly located in mcts and tube.

core::Actor is now a base class separated from MCTS.
ActorPlayer is a player backed by Actor, mostly used as a base for MctsPlayer and ForwardPlayer.
ForwardPlayer is a new player used for non-mcts things which just passes inputs/outputs directly to/from the actor (and thus the model).
The base Player class moved here from MCTS.

ModelManager is a refactor of ChannelAssembler from tube, as ChannelAssembler had grown out of scope of its original design. ModelManagers main purpose is to hold and run the model (for training). It also has some new code for finding the optimal batch size as used by workers.

The replay buffer moved here from MCTS and had a complete rewrite to improve some performance issues. Behavior should be the same as before.


State moved into the core namespace and had some (performance) improvements.
  - _Action is now not meant to be derived from. It thus no longer has virtual functions, and it is stored directly instead of through shared_ptr.
  There are two new functions clearActions() and addAction(x, y, z) which should be used to fill in the actions. If a game needs to store more information related to an action, they must do so internally in their State implementation, for instance in an array/vector which can be looked up by the index of the action (which will always be set in the order actions were added).
  - State implementations must now be copy-assignable (`State& operator=(State&)`). The default assignment operator works for most games, as long as they do not have const members.
  - FeatureOptions now stores the feature options, instead of them being static members. setFeatures must be called with a pointer to FeatureOptions. This object must outlive State itself. Game takes care of this normally.
  

Game has some new features and refactoring, but overall it grows larger, more complex and out of hand. I intent to refactor much of the logic and extract features out into separate classes which will interact with games through a common interface - but for now it is as it is.


- In some proportion of games, it will sometimes(/rarely) make a completely random move.
- In addition, on occasion, games will start with a series of random moves.
- There is support for logit value outputs from the model (ie a softmax output of win/loss/draw), though no models currently implement this. The value backpropagated to the mcts will be the probabilities of `win - loss` resulting in a range of [-1, 1] with 0 being draw. The MCTS, however, has no support yet for backpropagating the draw probability by itself. This probability could be used to implement resigning & automatic draw.
- There is experimental support for RNN models. This implementation unfortunately still has some issues when used with MCTS (but will not be too hard to fix in the future). There are, however, no RNN models yet.
- There is very experimental support for non-MCTS RL algorithms, though no suitable loss functions 
are implemented yet.
- There is also support for training against another model. This model can have a different architecture and featurization, and can even run a different game implementation, as long as the action space is shared. I'm not entirely sure about the usefulness of this right now, beyond speeding up training by training against good models from other runs.
- There is a new featurization turnFeaturesMultiChannel which does the same as the old turnFeatures (now turnFeaturesSingleChannel) - this has one channel per player, set to 1 if it is that players turn, and 0 otherwise. The reason is just that with only a single channel, there is a small bias near the edge of the board caused by conv padding.
- There is support for side learning through predicting the next N game states. It's also possible to target the last game state (predicting the end)
- There is a new "rewind" feature, which will, on game end, rewind the game to the last point where the model evaluated the game state as the opposite of the final outcome (effectively starting a new game from that game state). It will do this a specified number of times before starting a new game like normal.

There is also some new multithreading, with the idea being that any CPU processing should happen in small jobs which can be ran in parallel, and there is a fixed pool of threads that do this processing. game.cc has been partially updated to use this for stepping through games, but it still starts and ends games sequentially (this will be updated to be parallel later). MCTS uses this multithreading quite well.
