### PR TITLE
[6/8] Big merge - distributed

### DIFF
--- a/src/distributed/distributed.cc
+++ b/src/distributed/distributed.cc
@@ -1,12 +1,12 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
 
+#include "distributed.h"
 
-#include "reqrepserver.h"
+#include "rpc.h"
+
+#include "rdma.h"
+
+#define ZSTD_STATIC_LINKING_ONLY
+#include "zstd/lib/zstd.h"
 
 #include <fmt/printf.h>
 #include <torch/torch.h>
@@ -19,179 +19,184 @@
 #include <type_traits>
 #include <unordered_set>
 
-namespace tube {
+namespace distributed {
 
-// This is not a cross platform serializer
-struct Serializer {
-  std::vector<char> buf;
-  void write(const void* data, size_t len) {
-    size_t offset = buf.size();
-    if (buf.capacity() < offset + len) {
-      buf.reserve(
-          std::max(offset + len, std::max(buf.capacity() * 2, (size_t)16)));
-    }
-    buf.resize(offset + len);
-    std::memcpy(buf.data() + offset, data, len);
-  }
-  template <typename T, std::enable_if_t<std::is_trivial_v<T>>* = nullptr>
-  void write(T v) {
-    write((void*)&v, sizeof(v));
-  }
-
-  void write(std::string_view str) {
-    write(str.size());
-    write(str.data(), str.size());
-  }
-
-  template <typename Key, typename Value, typename... A>
-  void write(const std::unordered_map<Key, Value, A...>& v) {
-    writeMap(v);
-  }
-
-  void write(torch::Tensor v) {
-    std::ostringstream os;
-    torch::save(v, os);
-    write(os.str());
-  }
-
-  template <typename Key, typename Value, typename... A>
-  void writeMap(const std::unordered_map<Key, Value, A...>& v) {
-    write(v.size());
-    for (auto& x : v) {
-      write(x.first);
-      write(x.second);
-    }
-  }
-
-  void clear() {
-    buf.clear();
-  }
-  const char* data() const {
-    return buf.data();
-  }
-  size_t size() const {
-    return buf.size();
-  }
+struct NetStats {
+  bool hasData = false;
+  double sent = 0.0;
+  double received = 0.0;
+  double rpcCalls = 0.0;
+  double latency = 0.0;
+  std::chrono::steady_clock::time_point lastprint{};
+  std::mutex m;
 };
-struct Deserializer {
-  std::string_view buf;
-  Deserializer() = default;
-  Deserializer(std::string_view buf)
-      : buf(buf) {
+inline NetStats netstats;
+
+struct NetStatsCounter {
+  std::chrono::steady_clock::time_point timestamp{};
+  size_t sent = 0;
+  size_t received = 0;
+  size_t rpcCalls = 0;
+};
+
+template <typename T>
+void addnetworkstats(const T& obj, NetStatsCounter& counter) {
+  auto now = std::chrono::steady_clock::now();
+  auto elapsed = now - counter.timestamp;
+  if (elapsed <
+      (netstats.hasData ? std::chrono::seconds(1) : std::chrono::seconds(10))) {
+    return;
   }
-  Deserializer(const void* data, size_t len)
-      : buf((const char*)data, len) {
+  std::unique_lock l(netstats.m, std::try_to_lock);
+  if (!l.owns_lock()) {
+    return;
   }
-  void consume(size_t len) {
-    buf = {buf.data() + len, buf.size() - len};
+  counter.timestamp = now;
+  double t = std::chrono::duration_cast<
+                 std::chrono::duration<double, std::ratio<1, 1>>>(elapsed)
+                 .count();
+  size_t newSent = obj.bytesSent();
+  size_t newReceived = obj.bytesReceived();
+  size_t newCalls = obj.numRpcCalls();
+  double sent = (newSent - std::exchange(counter.sent, newSent)) / t;
+  double recv =
+      (newReceived - std::exchange(counter.received, newReceived)) / t;
+  double calls = (newCalls - std::exchange(counter.rpcCalls, newCalls)) / t;
+
+  double alpha = std::pow(0.99, t);
+  if (!netstats.hasData) {
+    alpha = 0.0;
+    netstats.hasData = true;
   }
-  std::string_view readString() {
-    size_t len = read<size_t>();
-    if (buf.size() < len) {
-      len = buf.size();
-    }
-    const char* data = buf.data();
-    consume(len);
-    return {data, len};
-  }
-  template <typename T, std::enable_if_t<std::is_trivial_v<T>>* = nullptr>
-  void read(T& r) {
-    if (buf.size() < sizeof(T)) {
-      consume(buf.size());
-      r = {};
-      return;
-    }
-    std::memcpy(&r, buf.data(), sizeof(T));
-    consume(sizeof(T));
-  }
-  void read(std::string_view& r) {
-    r = readString();
-  }
-  void read(std::string& r) {
-    r = readString();
-  }
-  template <typename Key, typename Value, typename... A>
-  void read(std::unordered_map<Key, Value, A...>& v) {
-    readMap(v);
+  netstats.sent = netstats.sent * alpha + sent * (1.0 - alpha);
+  netstats.received = netstats.received * alpha + recv * (1.0 - alpha);
+  netstats.rpcCalls = netstats.rpcCalls * alpha + calls * (1.0 - alpha);
+
+  constexpr bool haslatency = std::is_same_v<T, rpc::Client>;
+  if constexpr (haslatency) {
+    double ll = std::chrono::duration_cast<
+                    std::chrono::duration<double, std::ratio<1, 1000>>>(
+                    obj.lastLatency())
+                    .count();
+    netstats.latency = netstats.latency * alpha + ll * (1.0 - alpha);
   }
 
-  void read(torch::Tensor& v) {
-    auto s = read();
-    std::string str(s.data(), s.size());
-    std::istringstream is(str);
-    torch::load(v, is);
+  if (now - netstats.lastprint >= std::chrono::seconds(60)) {
+    netstats.lastprint = now;
+    if (haslatency) {
+      printf("Network stats: in: %.02fM/s out: %.02fM/s  RPC calls: %.02f/s "
+             "latency: %.02fms\n",
+             netstats.received / 1024 / 1024, netstats.sent / 1024 / 1024,
+             netstats.rpcCalls, netstats.latency);
+    } else {
+      printf("Network stats: in: %.02fM/s out: %.02fM/s  RPC calls: %.02f/s\n",
+             netstats.received / 1024 / 1024, netstats.sent / 1024 / 1024,
+             netstats.rpcCalls);
+    }
   }
+}
 
-  template <typename T> T read() {
-    T r;
-    read(r);
+inline rpc::Rpc& getRpc() {
+  static std::unique_ptr<rpc::Rpc> rpc = []() {
+    auto rpc = std::make_unique<rpc::Rpc>();
+    rpc->asyncRun(40);
+    return rpc;
+  }();
+  return *rpc;
+}
+
+struct RDMAModelInfo {
+  uint32_t checksum;
+  uint32_t key;
+  uintptr_t address;
+  size_t size;
+};
+
+struct Crc32 {
+  std::array<uint32_t, 256> lut;
+  Crc32() {
+    for (uint32_t i = 0; i != 256; ++i) {
+      uint32_t v = i;
+      for (size_t b = 0; b != 8; ++b) {
+        v = (v >> 1) ^ (v & 1 ? 0xedb88320 : 0);
+      }
+      lut[i] = v;
+    }
+  }
+  uint32_t operator()(const void* ptr, size_t size) {
+    uint32_t r = 0xffffffff;
+    unsigned char* c = (unsigned char*)ptr;
+    unsigned char* end = c + size;
+    while (c != end) {
+      r = (r >> 8) ^ lut[(r ^ *c++) & 0xff];
+    }
     return r;
   }
-  std::string_view read() {
-    return readString();
-  }
-  template <typename Key, typename Value, typename... A>
-  void readMap(std::unordered_map<Key, Value, A...>& v) {
-    v.clear();
-    size_t n = read<size_t>();
-    for (; n; --n) {
-      auto k = read<Key>();
-      v.emplace(std::move(k), read<Value>());
-    }
-  }
+} crc32;
 
-  bool empty() {
-    return buf.empty();
-  }
-};
+class ServerImpl {
 
-enum class MessageID {
-  MsgNull = 0,
-  MsgRequestModel = 1,
-  MsgReplyModel = 2,
-  MsgRequestStateDict = 3,
-  MsgReplyStateDict = 4,
-  MsgTrainData = 5,
-  MsgGameResult = 6,
-};
-
-class DistributedServer {
-
-  std::optional<cpid::ReqRepServer> server;
+  std::shared_ptr<rpc::Server> server;
 
   std::minstd_rand rng{std::random_device()()};
 
+  float rollChance(std::string_view id) {
+    auto i = models.find(id);
+    if (i == models.end()) {
+      return 0.0f;
+    }
+    float rating = i->second.rating;
+    float max = 0.0f;
+    std::vector<std::pair<float, std::string_view>> sorted;
+    for (auto& [id, m] : models) {
+      sorted.emplace_back(m.rating, id);
+      max = std::max(max, m.rating);
+    }
+    std::sort(sorted.begin(), sorted.end(), std::greater<>());
+    float lo = 1.0f;
+    float ret = 0.0f;
+    for (size_t i = 0; i != sorted.size(); ++i) {
+      auto [r, n] = sorted[i];
+      float x = r - max;
+      float o =
+          x == 0 ? 1.0f : std::min(std::log(1 - (2.0f * 200) / x) / 4, 1.0f);
+      if (r < rating) {
+        ret += (lo - o) / i;
+      }
+      lo = o;
+    }
+    ret += lo / sorted.size();
+    return ret;
+  }
+
   std::string_view sampleModelId() {
-    if (models.empty()) {
+    if (models.empty() ||
+        std::uniform_real_distribution<double>(0.0, 1.0)(rng) < 0.5) {
       return "dev";
     }
-    std::vector<std::pair<double, std::string_view>> scores;
-    float max = 0.0;
+    if (std::uniform_real_distribution<double>(0.0, 1.0)(rng) < 0.01) {
+      auto it = models.begin();
+      std::advance(
+          it, std::uniform_int_distribution<size_t>(0, models.size() - 1)(rng));
+      return it->first;
+    }
+
+    float max = 0.0f;
     for (auto& [id, m] : models) {
       max = std::max(max, m.rating);
     }
+    double x = std::uniform_real_distribution<double>(0.0, 1.0)(rng);
+    double target = -(2.0f / (std::exp(x * 4) - 1)) * 200;
+    std::vector<std::string_view> pool;
     for (auto& [id, m] : models) {
-      double v = std::exp((m.rating - max) / 400.0);
-      scores.emplace_back(v, id);
-    }
-    std::sort(scores.begin(), scores.end(), std::greater<>());
-    if (scores.size() > 24) {
-      scores.resize(24);
-    }
-    double sum = 0.0;
-    for (auto& [v, k] : scores) {
-      sum += v;
-    }
-    for (auto& [v, k] : scores) {
-      v /= sum;
-    }
-    double val =
-        std::uniform_real_distribution<double>(0.0, 1.0)(rng);
-    for (auto& [v, id] : scores) {
-      val -= v;
-      if (val <= 0) {
-        return id;
+      double diff = m.rating - max;
+      if (diff >= target) {
+        pool.push_back(id);
       }
+    }
+    if (!pool.empty()) {
+      return pool.at(
+          std::uniform_int_distribution<size_t>(0, pool.size() - 1)(rng));
     }
     return "dev";
   }
@@ -220,7 +225,7 @@ class DistributedServer {
     float devrating = di->second.rating;
 
     auto calc = [&](float reward, float diff) {
-      float k = 30;
+      float k = 6;
       float scale = 400;
       float offset = 0.5f;
       if (reward > 0) {
@@ -240,12 +245,27 @@ class DistributedServer {
     i->second.rating = rating;
     di->second.rating = devrating;
 
+    ++i->second.ngames;
+    ++di->second.ngames;
+
+    i->second.rewardsum += reward;
+    di->second.rewardsum -= reward;
+
+    i->second.avgreward = i->second.rewardsum / i->second.ngames;
+    di->second.avgreward = di->second.rewardsum / di->second.ngames;
+
     auto now = std::chrono::steady_clock::now();
     if (now - lastRatingPrint >= std::chrono::seconds(120)) {
       lastRatingPrint = now;
       std::vector<std::pair<float, std::string_view>> sorted;
       for (auto& [id, m] : models) {
         sorted.emplace_back(m.rating, id);
+
+        m.curgames = m.ngames - m.prevngames;
+        m.curreward = (m.rewardsum - m.prevrewardsum) / m.curgames;
+
+        m.prevngames = m.ngames;
+        m.prevrewardsum = m.rewardsum;
       }
       std::sort(sorted.begin(), sorted.end(), std::greater<>());
       int devrank = 0;
@@ -257,88 +277,291 @@ class DistributedServer {
           break;
         }
       }
-      if (sorted.size() > 10) {
-        sorted.resize(10);
+      if (sorted.size() > 20) {
+        sorted.resize(20);
       }
       std::string str;
       int rank = 1;
+      auto stringify = [&](int rank, float rating, std::string_view id) {
+        return fmt::sprintf("%d. %g %s (roll chance %f) (total %d games, %f "
+                            "avg reward) (diff %d games, %f avg reward)\n",
+                            rank, rating, id, rollChance(id), models[id].ngames,
+                            models[id].avgreward, models[id].curgames,
+                            models[id].curreward);
+      };
       for (auto& [rating, id] : sorted) {
-        str += fmt::sprintf("%d. %g %s\n",
-                            rank,
-                            rating,
-                            id);
+        str += stringify(rank, rating, id);
         ++rank;
       }
-      if (devrank > 10) {
-        str += fmt::sprintf("%d. %g %s\n",
-                            devrank,
-                            devrating,
-                            "dev");
+      if (devrank > 20) {
+        str += stringify(devrank, devrating, "dev");
       }
-      fmt::printf("Top 10:\n%s", str);
+      fmt::printf("Top 20:\n%s", str);
     }
   }
 
-  void onData(const void* data,
-              size_t len,
-              std::function<void(void const* buf, size_t len)> reply) {
+  std::pair<std::string_view, int> requestModel(bool wantsNewModelId,
+                                                std::string_view modelId) {
+    std::unique_lock l(mut);
+    if (wantsNewModelId) {
+      modelId = sampleModelId();
+    }
+    int version = -1;
+    auto i = models.find(modelId);
+    if (i == models.end()) {
+      modelId = "dev";
+      i = models.find(modelId);
+    }
+    if (i != models.end()) {
+      version = i->second.version;
+    } else {
+      version = -1;
+    }
+    addnetworkstats(*server, netstatsCounter);
+    return {modelId, version};
+  }
 
-    Serializer s;
+  std::optional<std::unordered_map<std::string, torch::Tensor>>
+  requestStateDict(std::string_view modelId) {
+    std::unique_lock l(mut);
+    auto i = models.find(modelId);
+    if (i == models.end()) {
+      return {};
+    } else {
+      return i->second.stateDict;
+    }
+  }
 
-    Deserializer d(data, len);
-    MessageID id = (MessageID)d.read<unsigned char>();
+  std::optional<std::vector<char>> requestCompressedStateDict(
+      std::string_view modelId) {
+    std::unique_lock l(mut);
+    auto i = models.find(modelId);
+    if (i == models.end()) {
+      return {};
+    } else {
+      if (i->second.compressedStateDict.empty()) {
+        for (int n = 0; n != 500 && i->second.compressing.exchange(true); ++n) {
+          l.unlock();
+          std::this_thread::sleep_for(std::chrono::milliseconds(50));
+          l.lock();
+          i = models.find(modelId);
+          if (i == models.end()) {
+            return {};
+          }
+          if (!i->second.compressedStateDict.empty()) {
+            return i->second.compressedStateDict;
+          }
+        }
+        auto copy = i->second.stateDict;
+        l.unlock();
+        auto start = std::chrono::steady_clock::now();
+        rpc::Serializer s;
+        rpc::Serialize ser(s);
+        ser(copy);
+        auto now = std::chrono::steady_clock::now();
+        double t1 =
+            std::chrono::duration_cast<
+                std::chrono::duration<double, std::ratio<1, 1000>>>(now - start)
+                .count();
+        start = now;
+        size_t oldsize = s.size();
+        s.compress(15);
+        size_t newsize = s.size();
+        s.buf.shrink_to_fit();
+        now = std::chrono::steady_clock::now();
+        double t2 =
+            std::chrono::duration_cast<
+                std::chrono::duration<double, std::ratio<1, 1000>>>(now - start)
+                .count();
+        start = now;
 
-    if (id == MessageID::MsgRequestModel) {
-      std::unique_lock l(mut);
-      bool wantsNewModelId = d.read<bool>();
-      std::string_view modelId = d.read();
-      if (wantsNewModelId) {
-        modelId = sampleModelId();
-      }
-      int version = -1;
-      auto i = models.find(modelId);
-      if (i == models.end()) {
-        modelId = "dev";
+        fmt::printf("State dict serialized in %gms, compressed (from %gM to "
+                    "%gM) in %gms\n",
+                    t1, oldsize / 1024.0 / 1024.0, newsize / 1024.0 / 1024.0,
+                    t2);
+
+        l.lock();
         i = models.find(modelId);
+        if (i == models.end()) {
+          return {};
+        }
+        i->second.compressedStateDict = std::move(s.buf);
+        i->second.compressing = false;
       }
-      if (i != models.end()) {
-        version = i->second.version;
+      return i->second.compressedStateDict;
+    }
+  }
+
+  void trainData(const std::unordered_map<std::string, torch::Tensor> data) {
+    onTrainData(std::move(data));
+  }
+
+  void gameResult(
+      std::vector<std::pair<float, std::unordered_map<std::string_view, float>>>
+          result) {
+    std::lock_guard l(mut);
+    for (auto& [reward, models] : result) {
+      for (auto& [id, ratio] : models) {
+        addResult(id, ratio, reward);
+      }
+    }
+  }
+
+  struct rdmaClient {
+    std::chrono::steady_clock::time_point timestamp;
+    std::unique_ptr<rdma::Host> host;
+    rdma::Endpoint localEp;
+    rdma::Endpoint remoteEp;
+  };
+
+  std::unique_ptr<rdma::Context> rdmaContext;
+  std::unique_ptr<rdma::CompletionQueue> rdmaCq;
+  std::list<rdmaClient> rdmaClients;
+  std::mutex rdmaMut;
+
+  rdma::Endpoint rdmaConnect(rdma::Endpoint ep) {
+    auto host = rdmaContext->createHost();
+    auto localEp = host->init(*rdmaCq);
+    host->connect(ep);
+
+    // fmt::printf("rdmaConnect, remoteEp %d:%d localEp %d:%d\n", ep.lid,
+    // ep.qpnum, localEp.lid, localEp.qpnum);
+
+    std::lock_guard l(rdmaMut);
+    auto now = std::chrono::steady_clock::now();
+    for (auto i = rdmaClients.begin(); i != rdmaClients.end();) {
+      if (now - i->timestamp >= std::chrono::minutes(1)) {
+        // fmt::printf("RDMA client %d:%d timed out\n", i->remoteEp.lid,
+        // i->remoteEp.qpnum);
+        i = rdmaClients.erase(i);
       } else {
-        version = -1;
+        ++i;
       }
-      s.write<char>((int)MessageID::MsgReplyModel);
-      s.write(modelId);
-      s.write<int>(version);
-    } else if (id == MessageID::MsgRequestStateDict) {
-      std::unique_lock l(mut);
-      std::string_view modelId = d.read();
-      s.write<char>((int)MessageID::MsgReplyStateDict);
-      auto i = models.find(modelId);
-      if (i == models.end()) {
-        s.write<bool>(false);
-      } else {
-        s.write<bool>(true);
-        s.write(i->second.stateDict);
+    }
+    rdmaClients.emplace_back();
+    auto& c = rdmaClients.back();
+    c.host = std::move(host);
+    c.localEp = localEp;
+    c.remoteEp = ep;
+    c.timestamp = now;
+    return localEp;
+  }
+
+  bool rdmaKeepalive(rdma::Endpoint remoteEp) {
+    std::unique_lock rl(rdmaMut);
+    for (auto i = rdmaClients.begin(); i != rdmaClients.end(); ++i) {
+      if (i->remoteEp == remoteEp) {
+        // fmt::printf("keepalive: rdma client %d:%d found, timestamp
+        // updated\n", remoteEp.lid, remoteEp.qpnum);
+        i->timestamp = std::chrono::steady_clock::now();
+        return true;
       }
-    } else if (id == MessageID::MsgTrainData) {
-      auto data = d.readString();
-      onTrainData(data.data(), data.size());
-    } else if (id == MessageID::MsgGameResult) {
-      std::lock_guard l(mut);
-      std::unordered_map<std::string_view, float> models;
-      while (!d.empty()) {
-        float reward = d.read<float>();
-        d.readMap(models);
-        for (auto& [id, ratio] : models) {
-          addResult(id, ratio, reward);
+    }
+    return false;
+  }
+
+  std::optional<RDMAModelInfo> rdmaGetModel(rdma::Endpoint remoteEp,
+                                            std::string_view modelId) {
+    try {
+      std::unique_lock rl(rdmaMut);
+      rdma::Endpoint localEp;
+      for (auto i = rdmaClients.begin(); i != rdmaClients.end(); ++i) {
+        if (i->remoteEp == remoteEp) {
+          i->timestamp = std::chrono::steady_clock::now();
+          localEp = i->localEp;
         }
       }
-    }
+      rl.unlock();
+      std::unique_lock l(mut);
+      auto i = models.find(modelId);
+      if (i == models.end()) {
+        return {};
+      }
+      for (int n = 0;; ++n) {
+        if (!i->second.rdmaBuffer ||
+            i->second.rdmaBufferVersion != i->second.version) {
+          if (n < 500 && i->second.rdmaSerializing.exchange(true)) {
+            l.unlock();
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            l.lock();
+            i = models.find(modelId);
+            if (i == models.end()) {
+              return {};
+            }
+          } else {
+            auto copy = i->second.stateDict;
+            int version = i->second.version;
+            l.unlock();
+            auto start = std::chrono::steady_clock::now();
+            rpc::Serializer s;
+            rpc::Serialize ser(s);
+            ser((uint32_t)0);
+            ser(copy);
 
-    if (s.size() == 0) {
-      s.write<char>((int)MessageID::MsgNull);
+            uint32_t checksum =
+                s.size() > 4 ? crc32(s.data() + 4, s.size() - 4) : 0;
+            std::memcpy((void*)s.data(), &checksum, 4);
+
+            l.lock();
+            i = models.find(modelId);
+            if (i == models.end()) {
+              return {};
+            }
+
+            auto buffer = std::move(i->second.rdmaBuffer);
+            auto storage = std::move(i->second.rdmaBufferStorage);
+            // if (buffer && storage.size() >= s.size()) {
+            if (false) {
+
+              storage.resize(s.size());
+              std::memcpy(storage.data(), s.data(), s.size());
+
+              auto now = std::chrono::steady_clock::now();
+              double t1 =
+                  std::chrono::duration_cast<
+                      std::chrono::duration<double, std::ratio<1, 1000>>>(now -
+                                                                          start)
+                      .count();
+              fmt::printf("State dict serialized and RDMA buffer updated in "
+                          "%gms, %gM (checksum %#x)\n",
+                          t1, storage.size() / 1024.0 / 1024.0, checksum);
+            } else {
+              i->second.rdmaBuffer_01 = std::move(buffer);
+              i->second.rdmaBufferStorage_01 = std::move(storage);
+
+              storage = std::move(s.buf);
+              buffer = rdmaContext->createBuffer(
+                  (void*)storage.data(), storage.size());
+
+              auto now = std::chrono::steady_clock::now();
+              double t1 =
+                  std::chrono::duration_cast<
+                      std::chrono::duration<double, std::ratio<1, 1000>>>(now -
+                                                                          start)
+                      .count();
+              fmt::printf("State dict serialized and RDMA buffer created in "
+                          "%gms, %gM (checksum %#x)\n",
+                          t1, storage.size() / 1024.0 / 1024.0, checksum);
+            }
+
+            i->second.rdmaBuffer = std::move(buffer);
+            i->second.rdmaBufferStorage = std::move(storage);
+            i->second.rdmaSerializing = false;
+            i->second.rdmaBufferVersion = version;
+          }
+        } else {
+          RDMAModelInfo r;
+          r.key = i->second.rdmaBuffer->keyFor(localEp);
+          r.checksum = i->second.rdmaBufferChecksum;
+          r.address = (uintptr_t)i->second.rdmaBufferStorage.data();
+          r.size = i->second.rdmaBufferStorage.size();
+          return r;
+        }
+      }
+    } catch (const std::exception& e) {
+      fmt::printf("rdmaGetModel error: %s\n", e.what());
+      return {};
     }
-    reply(s.data(), s.size());
   }
 
   struct ModelInfo {
@@ -346,22 +569,116 @@ class DistributedServer {
     int version = 0;
     float rating = 0.0f;
     std::unordered_map<std::string, torch::Tensor> stateDict;
+    std::vector<char> compressedStateDict;
+    std::atomic<bool> compressing{false};
+    uint64_t ngames = 0;
+    double rewardsum = 0.0;
+    float avgreward = 0.0f;
+
+    uint64_t prevngames = 0;
+    double prevrewardsum = 0.0;
+
+    uint64_t curgames = 0;
+    float curreward = 0.0f;
+
+    double rollChance = 0.0;
+
+    std::atomic<bool> rdmaSerializing{false};
+    std::vector<char> rdmaBufferStorage;
+    std::unique_ptr<rdma::Buffer> rdmaBuffer;
+    int rdmaBufferVersion = -1;
+    uint32_t rdmaBufferChecksum = 0;
+    std::vector<char> rdmaBufferStorage_01;
+    std::unique_ptr<rdma::Buffer> rdmaBuffer_01;
   };
 
   std::mutex mut;
   std::unordered_map<std::string_view, ModelInfo> models;
 
- public:
-  std::function<void(const void* data, size_t len)> onTrainData;
+  std::mutex timemut;
+  std::unordered_map<std::string, float> calltimes;
+  std::chrono::steady_clock::time_point lasttimereport;
 
-  void start(std::string endpoint) {
-    server.emplace(std::bind(&DistributedServer::onData,
-                             this,
-                             std::placeholders::_1,
-                             std::placeholders::_2,
-                             std::placeholders::_3),
-                   4,
-                   endpoint);
+ public:
+  std::function<void(const std::unordered_map<std::string, torch::Tensor>)>
+      onTrainData;
+  NetStatsCounter netstatsCounter;
+
+  template <typename R, typename... Args>
+  auto define(std::string name, R (ServerImpl::*f)(Args...)) {
+    server->define(
+        name, std::function<R(Args...)>([this, f, name](Args&&... args) {
+          auto begin = std::chrono::steady_clock::now();
+          auto finish = [&]() {
+            auto end = std::chrono::steady_clock::now();
+            double t = std::chrono::duration_cast<
+                           std::chrono::duration<double, std::ratio<1, 1000>>>(
+                           end - begin)
+                           .count();
+            {
+              std::unique_lock l(timemut);
+              auto i = calltimes.find(name);
+              if (i == calltimes.end()) {
+                i = calltimes.emplace(name, t).first;
+              }
+              float& v = i->second;
+              v = v * 0.99 + t * 0.01;
+
+              if (end - lasttimereport >= std::chrono::seconds(60)) {
+                lasttimereport = end;
+                std::string s = "RPC call times (running average):\n";
+                for (auto& v : calltimes) {
+                  s += fmt::sprintf("  %s  %fms\n", v.first, v.second);
+                }
+                l.unlock();
+                fmt::printf("%s", s);
+              }
+            }
+          };
+          if constexpr (std::is_same_v<R, void>) {
+            (this->*f)(std::forward<Args>(args)...);
+            finish();
+          } else {
+            auto rv = (this->*f)(std::forward<Args>(args)...);
+            finish();
+            return rv;
+          }
+        }));
+  }
+
+  void start(std::string_view endpoint) {
+    if (endpoint.substr(0, 6) == "tcp://") {
+      endpoint.remove_prefix(6);
+    }
+    printf("actual listen endpoint is %s\n", std::string(endpoint).c_str());
+    server = getRpc().listen("");
+
+    define("requestModel", &ServerImpl::requestModel);
+    define("requestStateDict", &ServerImpl::requestStateDict);
+    define(
+        "requestCompressedStateDict", &ServerImpl::requestCompressedStateDict);
+    define("trainData", &ServerImpl::trainData);
+    define("gameResult", &ServerImpl::gameResult);
+
+    try {
+      rdmaContext = rdma::create();
+      if (!rdmaContext) {
+        fmt::printf("RDMA/IB is not supported\n");
+      } else {
+        rdmaCq = rdmaContext->createCQ(4);
+        auto testHost = rdmaContext->createHost();
+
+        define("rdmaConnect", &ServerImpl::rdmaConnect);
+        define("rdmaKeepalive", &ServerImpl::rdmaKeepalive);
+        define("rdmaGetModel", &ServerImpl::rdmaGetModel);
+
+        fmt::printf("RDMA over IB supported\n");
+      }
+    } catch (const std::exception& e) {
+      fmt::printf("RDMA error: %s\nRDMA/IB will not be used\n", e.what());
+    }
+
+    server->listen(endpoint);
   }
 
   void updateModel(const std::string& id,
@@ -369,80 +686,234 @@ class DistributedServer {
     std::unique_lock l(mut);
     auto i = models.try_emplace(id);
     if (i.second) {
+      i.first->second.version =
+          std::uniform_int_distribution<int>(0, 10000)(rng) * 1000;
       i.first->second.id = id;
       (std::string_view&)i.first->first = i.first->second.id;
       auto idev = models.find("dev");
       if (idev != models.end()) {
-        i.first->second.rating = idev->second.rating - 100;
+        i.first->second.rating = idev->second.rating;
       }
     }
     auto& m = i.first->second;
     m.stateDict = std::move(stateDict);
     ++m.version;
+    m.compressedStateDict.clear();
   }
 };
 
-class DistributedClient {
+class ClientImpl {
 
-  std::optional<cpid::ReqRepClient> client;
+  std::shared_ptr<rpc::Client> client;
 
-  std::mutex mut;
+  mutable std::mutex mut;
   std::unordered_set<std::string> allModelIds;
   std::string_view currentModelId = *allModelIds.emplace("dev").first;
   int currentModelVersion = -1;
   int gamesDoneWithCurrentModel = 0;
   bool wantsNewModelId = false;
+  bool wantsTournamentResult_ = false;
 
-  void send(Serializer& s) {
-    recv(client->request(std::move(s.buf)).get());
-  }
-
-  void recv(std::vector<char> buf) {
-    Deserializer d(buf.data(), buf.size());
-    MessageID id = (MessageID)d.read<unsigned char>();
-    if (id == MessageID::MsgReplyModel) {
-      std::string_view newId = d.readString();
-      std::unique_lock l(mut);
-      if (currentModelId != newId) {
-        currentModelId = *allModelIds.emplace(newId).first;
-        currentModelVersion = -1;
-        gamesDoneWithCurrentModel = 0;
-      }
-      int version = d.read<int>();
-      if (version != currentModelVersion) {
-        currentModelVersion = version;
-        l.unlock();
-        requestModelStateDict();
-      } else {
-        l.unlock();
-      }
-    } else if (id == MessageID::MsgReplyStateDict) {
-      std::unordered_map<std::string, torch::Tensor> stateDict;
-      bool success = d.read<bool>();
-      if (!success) {
-        std::lock_guard l(mut);
-        currentModelId = "dev";
-        currentModelVersion = -1;
-      } else {
-        std::unique_lock l(mut);
-        auto id = currentModelId;
-        l.unlock();
-        d.read(stateDict);
-        onUpdateModel(id, stateDict);
-      }
-    }
-  }
+  std::chrono::steady_clock::time_point lastCheckTournamentResult =
+      std::chrono::steady_clock::now();
+  std::chrono::steady_clock::time_point lastTournamentResult =
+      std::chrono::steady_clock::now();
 
   std::vector<std::pair<float, std::unordered_map<std::string_view, float>>>
       resultQueue;
 
-  void requestModelStateDict() {
-    Serializer s;
-    s.write<char>((int)MessageID::MsgRequestStateDict);
-    std::unique_lock l(mut);
-    s.write(currentModelId);
-    l.unlock();
-    send(s);
+  NetStatsCounter netstatsCounter;
+
+  std::unique_ptr<rdma::Context> rdmaContext;
+  std::unique_ptr<rdma::Host> rdmaHost;
+  std::unique_ptr<rdma::Buffer> rdmaBuffer;
+  size_t rdmaBufferSize = 0;
+  std::vector<char> rdmaBufferStorage;
+  std::optional<rdma::Endpoint> rdmaEndpoint;
+  std::unique_ptr<rdma::CompletionQueue> rdmaCq;
+
+  std::mutex trainDataMut;
+  std::vector<std::future<void>> trainDataFutures;
+
+  struct Bandit {
+    std::mutex mut;
+    std::unordered_map<std::string, float> value;
+    std::minstd_rand rng{std::random_device{}()};
+    float sample(std::string name, float weight = 1.0f) {
+      std::lock_guard l(mut);
+      return std::uniform_real_distribution<float>(
+          0.0f, std::exp(value[name] * 4) * weight)(rng);
+    }
+    float get(std::string name) {
+      std::lock_guard l(mut);
+      return value[name];
+    }
+  };
+
+  struct BanditResultCounter {
+    Bandit& b;
+    std::string name;
+    bool succeeded_ = false;
+    BanditResultCounter(Bandit& b, std::string name)
+        : b(b)
+        , name(std::move(name)) {
+    }
+    void success(bool succeeded = true) {
+      succeeded_ = succeeded;
+    }
+    ~BanditResultCounter() {
+      std::lock_guard l(b.mut);
+      float& v = b.value[name];
+      v = v * 0.95f + (succeeded_ ? 1.0f : -1.0f) * 0.05f;
+    }
+  };
+
+  Bandit bandit;
+
+  bool createRdmaHost() {
+    if (!rdmaContext) {
+      return false;
+    }
+    if (rdmaHost) {
+      return true;
+    }
+    try {
+      rdmaHost = rdmaContext->createHost();
+      return true;
+    } catch (const std::exception& e) {
+      fmt::printf("RDMA error: %s\nRDMA/IB will not be used\n", e.what());
+      return false;
+    }
+  }
+
+  void requestModelStateDict(std::string modelId, int modelVersion) {
+    try {
+
+      auto start = std::chrono::steady_clock::now();
+
+      float rdmaValue = bandit.get("rdma");
+      float rpcValue = bandit.get("rpc");
+
+      fmt::printf("bandit values: rdma %g rpc %g\n", rdmaValue, rpcValue);
+
+      if ((rdmaHost || createRdmaHost()) &&
+          (rdmaValue >= 0.75f || (rdmaValue >= 0.0f && rpcValue < 0.5f) ||
+           bandit.sample("rdma", 4.0f) > bandit.sample("rpc"))) {
+
+        BanditResultCounter bc(bandit, "rdma");
+
+        try {
+
+          if (!rdmaEndpoint) {
+
+            rdmaCq = rdmaContext->createCQ(4);
+            rdmaEndpoint = rdmaHost->init(*rdmaCq);
+
+            fmt::printf("local endpoint is %d:%d\n", rdmaEndpoint->lid,
+                        rdmaEndpoint->qpnum);
+
+            auto remoteEp =
+                client->sync<rdma::Endpoint>("rdmaConnect", *rdmaEndpoint);
+            addnetworkstats(*client, netstatsCounter);
+
+            fmt::printf(
+                "remote endpoint is %d:%d\n", remoteEp.lid, remoteEp.qpnum);
+
+            rdmaHost->connect(remoteEp);
+          }
+
+          auto result = client->async<std::optional<RDMAModelInfo>>(
+              "rdmaGetModel", *rdmaEndpoint, modelId);
+          auto mi = result.get();
+
+          if (!mi) {
+            std::lock_guard l(mut);
+            currentModelId = "dev";
+            currentModelVersion = -1;
+          } else {
+
+            if (!rdmaBuffer || rdmaBufferSize < mi->size) {
+              rdmaBufferStorage.resize(mi->size);
+              rdmaBuffer =
+                  rdmaContext->createBuffer(rdmaBufferStorage.data(), mi->size);
+            }
+
+            rdmaHost->read(*rdmaBuffer, rdmaBufferStorage.data(), mi->key,
+                           mi->address, mi->size);
+            rdmaHost->wait();
+
+            std::unordered_map<std::string, torch::Tensor> stateDict;
+            rpc::Deserializer d(rdmaBufferStorage.data(), mi->size);
+            rpc::Deserialize des(d);
+            uint32_t checksum = 0;
+            des(checksum);
+            if (mi->size > 4 &&
+                crc32(rdmaBufferStorage.data() + 4, mi->size - 4) == checksum) {
+              fmt::printf("RDMA model checksum OK (%#x)\n", checksum);
+              des(stateDict);
+              onUpdateModel(modelId, stateDict);
+              std::lock_guard l(mut);
+              if (currentModelId != modelId) {
+                currentModelId = *allModelIds.emplace(modelId).first;
+                gamesDoneWithCurrentModel = 0;
+              }
+              currentModelVersion = modelVersion;
+              fmt::printf("Got model '%s' version %d\n", modelId, modelVersion);
+              bc.success();
+            } else {
+              fmt::printf("RDMA model checksum error\n");
+              return;
+            }
+          }
+
+        } catch (const rdma::Error& e) {
+          fmt::printf("RDMA error: %s\n", e.what());
+
+          rdmaEndpoint.reset();
+          rdmaHost.reset();
+          rdmaCq.reset();
+          return;
+        }
+
+      } else {
+
+        BanditResultCounter bc(bandit, "rpc");
+
+        auto result = client->async<std::optional<std::vector<char>>>(
+            "requestCompressedStateDict", modelId);
+        auto compressed = result.get();
+        addnetworkstats(*client, netstatsCounter);
+        if (!compressed) {
+          std::unique_lock l(mut);
+          currentModelId = "dev";
+          currentModelVersion = -1;
+        } else {
+          std::unordered_map<std::string, torch::Tensor> stateDict;
+          rpc::Deserializer d(compressed->data(), compressed->size());
+          d.decompress();
+          rpc::Deserialize des(d);
+          des(stateDict);
+          onUpdateModel(modelId, stateDict);
+          std::unique_lock l(mut);
+          if (currentModelId != modelId) {
+            currentModelId = *allModelIds.emplace(modelId).first;
+            gamesDoneWithCurrentModel = 0;
+          }
+          currentModelVersion = modelVersion;
+          fmt::printf("Got model '%s' version %d\n", modelId, modelVersion);
+          bc.success();
+        }
+      }
+
+      double t = std::chrono::duration_cast<
+                     std::chrono::duration<double, std::ratio<1, 1000>>>(
+                     std::chrono::steady_clock::now() - start)
+                     .count();
+      fmt::printf("State dict received and updated in %gms\n", t);
+
+    } catch (const rpc::RPCException& e) {
+      fmt::printf("RPC exception: %s\n", e.what());
+    }
   }
 
  public:
@@ -450,40 +921,111 @@ class DistributedClient {
       std::string_view, std::unordered_map<std::string, torch::Tensor>)>
       onUpdateModel;
 
-  void requestModel(bool isTournamentOpponent) {
-    std::unique_lock l(mut);
-    Serializer s;
-    if (!resultQueue.empty()) {
-      s.write<char>((int)MessageID::MsgGameResult);
-      for (auto& v : resultQueue) {
-        s.write<float>(v.first);
-        s.writeMap(v.second);
+  ClientImpl() {
+    try {
+      rdmaContext = rdma::create();
+      if (!rdmaContext) {
+        fmt::printf("RDMA/IB is not supported\n");
+      } else {
+        rdmaHost = rdmaContext->createHost();
+
+        fmt::printf("Using RDMA over IB for model transfers\n");
       }
-      resultQueue.clear();
-      l.unlock();
-      send(s);
-      s.clear();
-      l.lock();
+    } catch (const std::exception& e) {
+      fmt::printf("RDMA error: %s\nRDMA/IB will not be used\n", e.what());
     }
-
-    s.write<char>((int)MessageID::MsgRequestModel);
-    s.write<bool>(isTournamentOpponent ? std::exchange(wantsNewModelId, false)
-                                       : false);
-    s.write(currentModelId);
-    l.unlock();
-    send(s);
   }
 
-  void connect(std::string host) {
-    client.emplace(50, std::vector<std::string>{host});
-    requestModel(false);
+  void requestModel(bool isTournamentOpponent) {
+    try {
+      std::unique_lock l(mut);
+      if (!resultQueue.empty()) {
+        client->async("gameResult", resultQueue);
+        resultQueue.clear();
+      }
+
+      //      fmt::printf(
+      //          "Request model, isTournamentOpponent %d, wantsNewModelId
+      //          %d\n", isTournamentOpponent, wantsNewModelId);
+
+      auto result = client->async<std::pair<std::string, int>>(
+          "requestModel",
+          isTournamentOpponent ? std::exchange(wantsNewModelId, false) : false,
+          currentModelId);
+      l.unlock();
+
+      if (rdmaEndpoint) {
+        if (!client->sync<bool>("rdmaKeepalive", *rdmaEndpoint)) {
+          rdmaEndpoint.reset();
+          rdmaHost.reset();
+          rdmaCq.reset();
+        }
+      }
+
+      auto [newId, version] = result.get();
+      addnetworkstats(*client, netstatsCounter);
+
+      // fmt::printf("Got model '%s'\n", newId);
+
+      l.lock();
+      auto now = std::chrono::steady_clock::now();
+      if (isTournamentOpponent &&
+          now - lastCheckTournamentResult >= std::chrono::minutes(2)) {
+        lastCheckTournamentResult = now;
+        wantsTournamentResult_ =
+            now - lastTournamentResult >= std::chrono::minutes(5);
+        if (!wantsTournamentResult_) {
+          wantsNewModelId = true;
+        }
+        //        fmt::printf("wantsTournamentResult_ is %d, wantsNewModelId is
+        //        %d\n",
+        //                    wantsTournamentResult_,
+        //                    wantsNewModelId);
+      } else if (!isTournamentOpponent) {
+        wantsTournamentResult_ = false;
+      }
+      if (currentModelId != newId || version != currentModelVersion) {
+        l.unlock();
+        requestModelStateDict(newId, version);
+      } else {
+        l.unlock();
+      }
+    } catch (const rpc::RPCException& e) {
+      fmt::printf("RPC exception: %s\n", e.what());
+    }
   }
 
-  void sendTrainData(const void* data, size_t len) {
-    Serializer s;
-    s.write<char>((int)MessageID::MsgTrainData);
-    s.write(std::string_view((const char*)data, len));
-    send(s);
+  void connect(std::string_view endpoint) {
+    if (endpoint.substr(0, 6) == "tcp://") {
+      endpoint.remove_prefix(6);
+    }
+    printf("actual connect endpoint is %s\n", std::string(endpoint).c_str());
+    client = getRpc().connect(endpoint);
+  }
+
+  void sendTrainData(
+      const std::unordered_map<std::string, torch::Tensor>& data) {
+    try {
+      std::unique_lock l(trainDataMut);
+      std::future<void> fut;
+      if (trainDataFutures.size() >= 32) {
+        fut = std::move(trainDataFutures.front());
+        trainDataFutures.erase(trainDataFutures.begin());
+      }
+      l.unlock();
+      if (fut.valid()) {
+        fut.get();
+      }
+    } catch (const rpc::RPCException& e) {
+      fmt::printf("RPC exception: %s\n", e.what());
+    }
+    try {
+      auto fut = client->async<void>("trainData", data);
+      std::lock_guard l(trainDataMut);
+      trainDataFutures.push_back(std::move(fut));
+    } catch (const rpc::RPCException& e) {
+      fmt::printf("RPC exception: %s\n", e.what());
+    }
   }
 
   void sendResult(float reward,
@@ -493,7 +1035,8 @@ class DistributedClient {
     if (i != models.end()) {
       if (i->second >= 0.9f) {
         ++gamesDoneWithCurrentModel;
-        if (gamesDoneWithCurrentModel >= 8) {
+        if (gamesDoneWithCurrentModel >= 20) {
+          lastTournamentResult = std::chrono::steady_clock::now();
           wantsNewModelId = true;
         }
       }
@@ -501,10 +1044,77 @@ class DistributedClient {
     resultQueue.emplace_back(reward, std::move(models));
   }
 
-  std::string_view getModelId() {
+  bool wantsTournamentResult() const {
+    std::unique_lock l(mut);
+    return wantsTournamentResult_;
+  }
+
+  std::string_view getModelId() const {
     std::unique_lock l(mut);
     return currentModelId;
   }
 };
 
-}  // namespace tube
+Server::Server() {
+  impl = std::make_unique<ServerImpl>();
+}
+Server::~Server() {
+}
+
+void Server::setOnTrainData(
+    std::function<void(std::unordered_map<std::string, torch::Tensor>)>
+        onTrainData) {
+  impl->onTrainData = std::move(onTrainData);
+}
+
+void Server::start(std::string endpoint) {
+  impl->start(endpoint);
+}
+
+void Server::updateModel(
+    const std::string& id,
+    std::unordered_map<std::string, torch::Tensor> stateDict) {
+  impl->updateModel(id, std::move(stateDict));
+}
+
+Client::Client() {
+  impl = std::make_unique<ClientImpl>();
+}
+
+Client::~Client() {
+}
+
+void Client::setOnUpdateModel(
+    std::function<void(std::string_view,
+                       std::unordered_map<std::string, torch::Tensor>)>
+        onUpdateModel) {
+  impl->onUpdateModel = std::move(onUpdateModel);
+}
+
+void Client::connect(std::string endpoint) {
+  impl->connect(endpoint);
+}
+
+void Client::requestModel(bool isTournamentOpponent) {
+  impl->requestModel(isTournamentOpponent);
+}
+
+void Client::sendTrainData(
+    const std::unordered_map<std::string, torch::Tensor>& data) {
+  impl->sendTrainData(data);
+}
+
+bool Client::wantsTournamentResult() {
+  return impl->wantsTournamentResult();
+}
+
+std::string_view Client::getModelId() {
+  return impl->getModelId();
+}
+
+void Client::sendResult(float reward,
+                        std::unordered_map<std::string_view, float> models) {
+  impl->sendResult(reward, std::move(models));
+}
+
+}  // namespace distributed

--- a/src/distributed/distributed.h
+++ b/src/distributed/distributed.h
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <torch/torch.h>
+#include <unordered_map>
+
+namespace rpc {
+
+template <typename X, typename A, typename B>
+void serialize(X& x, const std::pair<A, B>& v) {
+  x(v.first, v.second);
+}
+
+template <typename X, typename A, typename B>
+void serialize(X& x, std::pair<A, B>& v) {
+  x(v.first, v.second);
+}
+
+template <typename X, typename T>
+void serialize(X& x, const std::optional<T>& v) {
+  x(v.has_value());
+  if (v.has_value()) {
+    x(v.value());
+  }
+}
+
+template <typename X, typename T> void serialize(X& x, std::optional<T>& v) {
+  if (x.template read<bool>()) {
+    v.emplace();
+    x(v.value());
+  } else {
+    v.reset();
+  }
+}
+
+template <typename X, typename T>
+void serialize(X& x, const std::vector<T>& v) {
+  x(v.size());
+  for (auto& v2 : v) {
+    x(v2);
+  }
+}
+
+template <typename X, typename T> void serialize(X& x, std::vector<T>& v) {
+  size_t n = x.template read<size_t>();
+  v.resize(n);
+  for (size_t i = 0; i != n; ++i) {
+    x(v[i]);
+  }
+}
+
+template <typename X, typename Key, typename Value>
+void serialize(X& x, const std::unordered_map<Key, Value>& v) {
+  x(v.size());
+  for (auto& v2 : v) {
+    x(v2.first, v2.second);
+  }
+}
+
+template <typename X, typename Key, typename Value>
+void serialize(X& x, std::unordered_map<Key, Value>& v) {
+  v.clear();
+  size_t n = x.template read<size_t>();
+  for (; n; --n) {
+    auto k = x.template read<Key>();
+    v.emplace(std::move(k), x.template read<Value>());
+  }
+}
+
+template <typename X> void serialize(X& x, const torch::Tensor& v) {
+  if (!v.is_contiguous()) {
+    serialize(x, v.contiguous());
+    return;
+  }
+  x(v.scalar_type(),
+    std::basic_string_view<int64_t>(v.sizes().data(), v.sizes().size()));
+  void* data = v.data_ptr();
+  size_t size = v.numel() * v.dtype().itemsize();
+  x(std::string_view((const char*)data, size));
+}
+
+template <typename X> void serialize(X& x, torch::Tensor& v) {
+  torch::ScalarType dtype;
+  std::basic_string_view<int64_t> sizes;
+  x(dtype, sizes);
+  if (v.defined() && v.scalar_type() == dtype) {
+    v.resize_(torch::IntArrayRef(sizes.begin(), sizes.end()));
+  } else {
+    v = torch::empty(torch::IntArrayRef(sizes.begin(), sizes.end()), dtype);
+  }
+  std::string_view data;
+  x(data);
+  if ((size_t)v.numel() != data.size() / v.dtype().itemsize()) {
+    throw std::runtime_error("numel mismatch in tensor deserialize");
+  }
+  std::memcpy(v.data_ptr(), data.data(), data.size());
+}
+
+}  // namespace rpc
+
+namespace distributed {
+
+class ServerImpl;
+class ClientImpl;
+
+class Server {
+  std::unique_ptr<ServerImpl> impl;
+
+ public:
+  Server();
+  ~Server();
+
+  void setOnTrainData(
+      std::function<
+          void(const std::unordered_map<std::string, torch::Tensor>)>);
+  void start(std::string endpoint);
+  void updateModel(const std::string& id,
+                   std::unordered_map<std::string, torch::Tensor> stateDict);
+};
+
+class Client {
+  std::unique_ptr<ClientImpl> impl;
+
+ public:
+  Client();
+  ~Client();
+
+  void setOnUpdateModel(
+      std::function<void(std::string_view,
+                         std::unordered_map<std::string, torch::Tensor>)>);
+  void connect(std::string endpoint);
+  void requestModel(bool isTournamentOpponent);
+  void sendTrainData(
+      const std::unordered_map<std::string, torch::Tensor>& data);
+  bool wantsTournamentResult();
+  std::string_view getModelId();
+  void sendResult(float reward,
+                  std::unordered_map<std::string_view, float> models);
+};
+
+}  // namespace distributed

--- a/src/distributed/ib.cc
+++ b/src/distributed/ib.cc
@@ -1,0 +1,539 @@
+
+#include "rdma.h"
+
+#include <infiniband/verbs.h>
+
+#include <deque>
+#include <list>
+#include <optional>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace ib {
+
+struct Device {
+  std::string name;
+  ibv_device* info;
+};
+
+struct DeviceList {
+
+  std::vector<Device> list;
+  ibv_device** rawlist = nullptr;
+
+  DeviceList() {
+    int num = 0;
+    rawlist = ibv_get_device_list(&num);
+    for (int i = 0; i < num; ++i) {
+      Device d;
+      d.name = rawlist[i]->name;
+      d.info = rawlist[i];
+      list.push_back(d);
+    }
+  }
+  ~DeviceList() {
+    if (rawlist) {
+      ibv_free_device_list(rawlist);
+    }
+  }
+
+  size_t size() const {
+    return list.size();
+  }
+
+  auto begin() const {
+    return list.begin();
+  }
+  auto end() const {
+    return list.end();
+  }
+
+  bool empty() const {
+    return list.empty();
+  }
+
+  decltype(auto) operator[](size_t index) const {
+    return list[index];
+  }
+};
+
+class Error : public rdma::Error {
+ public:
+  using rdma::Error::Error;
+};
+
+std::string gidstr(std::array<std::byte, 16> gid) {
+  std::string s;
+  for (auto& v : gid) {
+    s += "0123456789abcdef"[unsigned(v) >> 4];
+    s += "0123456789abcdef"[unsigned(v) & 0xf];
+  }
+  return s;
+}
+
+struct Port {
+  ibv_context* context = nullptr;
+  int num = 0;
+  ibv_port_attr attr;
+  uint32_t lid() {
+    return attr.lid;
+  }
+  std::array<std::byte, 16> gid() {
+    std::array<std::byte, 16> gid;
+    static_assert(sizeof(gid) == sizeof(ibv_gid));
+    if (ibv_query_gid(context, num, 0, (ibv_gid*)&gid)) {
+      throw Error("ibv_query_gid failed");
+    }
+    return gid;
+  }
+};
+
+struct NoMove {
+  NoMove() = default;
+  NoMove(const NoMove&) = delete;
+  NoMove(NoMove&&) = delete;
+  NoMove& operator=(const NoMove&) = delete;
+  NoMove& operator=(NoMove&&) = delete;
+};
+
+struct Context : NoMove {
+  ibv_context* context = nullptr;
+  ibv_device_attr devattr;
+  std::vector<Port> ports;
+  Context(const Device& dev) {
+    context = ibv_open_device(dev.info);
+    if (!context) {
+      throw Error("Failed to open device " + dev.name);
+    }
+    memset(&devattr, 0, sizeof(devattr));
+    ibv_query_device(context, &devattr);
+
+    for (int i = 1; i <= devattr.phys_port_cnt; ++i) {
+      ports.emplace_back();
+      ports.back().context = context;
+      ports.back().num = i;
+      auto& attr = ports.back().attr;
+      memset(&attr, 0, sizeof(attr));
+      ibv_query_port(context, i, &attr);
+    }
+  }
+  ~Context() {
+    if (context) {
+      ibv_close_device(context);
+      context = nullptr;
+    }
+  }
+};
+
+struct ProtectionDomain : NoMove {
+  ibv_pd* pd = nullptr;
+  ProtectionDomain(Context& ctx) {
+    pd = ibv_alloc_pd(ctx.context);
+    if (!pd) {
+      throw Error("Failed to allocate protection domain");
+    }
+  }
+  ~ProtectionDomain() {
+    if (pd) {
+      ibv_dealloc_pd(pd);
+      pd = nullptr;
+    }
+  }
+};
+
+struct MemoryRegion : NoMove {
+  ibv_mr* mr = nullptr;
+  MemoryRegion(const ProtectionDomain& pd,
+               void* address,
+               size_t size,
+               int access) {
+    mr = ibv_reg_mr(pd.pd, address, size, access);
+    if (!mr) {
+      throw Error("Failed to register memory region");
+    }
+  }
+  ~MemoryRegion() {
+    if (mr) {
+      ibv_dereg_mr(mr);
+      mr = nullptr;
+    }
+  }
+  auto lkey() {
+    return mr->lkey;
+  }
+  auto rkey() {
+    return mr->rkey;
+  }
+};
+
+struct CompletionQueue : NoMove {
+  ibv_cq* cq = nullptr;
+  CompletionQueue(const Context& ctx, int size) {
+    cq = ibv_create_cq(ctx.context, size, nullptr, nullptr, 0);
+    if (!cq) {
+      throw Error("Failed to create completion queue");
+    }
+  }
+  ~CompletionQueue() {
+    if (cq) {
+      int e = ibv_destroy_cq(cq);
+      if (e) {
+        throw std::runtime_error("ibv_destroy_cq failed with error " +
+                                 std::to_string(e));
+      }
+      cq = nullptr;
+    }
+  }
+
+  void wait() {
+    ibv_wc wc;
+    auto start = std::chrono::steady_clock::now();
+    while (true) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      if (std::chrono::steady_clock::now() - start >=
+          std::chrono::seconds(10)) {
+        throw Error("wait timed out");
+      }
+      int r = ibv_poll_cq(cq, 1, &wc);
+      if (r > 0) {
+        if (wc.status != IBV_WC_SUCCESS) {
+          throw Error(ibv_wc_status_str(wc.status));
+        }
+        return;
+      } else if (r < 0) {
+        throw Error("Failed to poll the completion queue");
+      }
+    }
+  }
+};
+
+struct QueuePair : NoMove {
+  ibv_qp* qp = nullptr;
+  QueuePair(const ProtectionDomain& pd, const CompletionQueue& cq) {
+    ibv_qp_init_attr init;
+    memset(&init, 0, sizeof(init));
+    init.send_cq = cq.cq;
+    init.recv_cq = cq.cq;
+    init.qp_type = IBV_QPT_RC;
+    init.cap.max_send_wr = 2;
+    init.cap.max_recv_wr = 2;
+    init.cap.max_send_sge = 1;
+    init.cap.max_recv_sge = 1;
+
+    qp = ibv_create_qp(pd.pd, &init);
+    if (!qp) {
+      throw Error("Failed to create queue pair");
+    }
+  }
+  ~QueuePair() {
+    if (qp) {
+      ibv_destroy_qp(qp);
+    }
+  }
+
+  uint32_t num() {
+    return qp->qp_num;
+  }
+
+  void init(const Port& port, int accessFlags) {
+    ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_INIT;
+    attr.pkey_index = 0;
+    attr.port_num = port.num;
+    attr.qp_access_flags = accessFlags;
+    int err = ibv_modify_qp(
+        qp, &attr,
+        IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS);
+    if (err) {
+      throw Error("Failed to move queue pair to init state; error " +
+                  std::to_string(err));
+    }
+  }
+
+  void rtr(const Port& port,
+           uint16_t remoteLid,
+           uint32_t remoteQPNum,
+           const std::array<std::byte, 16>& gid) {
+    ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTR;
+    attr.path_mtu = port.attr.active_mtu;
+    attr.dest_qp_num = remoteQPNum;
+    attr.rq_psn = 4242;
+    attr.max_dest_rd_atomic = 1;
+    attr.min_rnr_timer = 12;
+    attr.ah_attr.is_global = 0;
+    attr.ah_attr.dlid = remoteLid;
+    attr.ah_attr.sl = 0;
+    attr.ah_attr.src_path_bits = 0;
+    attr.ah_attr.port_num = port.num;
+
+    attr.ah_attr.is_global = 1;
+    attr.ah_attr.grh.hop_limit = 4;
+    attr.ah_attr.grh.dgid = (ibv_gid&)gid;
+    attr.ah_attr.grh.sgid_index = 0;
+    int err = ibv_modify_qp(
+        qp, &attr,
+        IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+            IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER);
+    if (err) {
+      throw Error("Failed to move queue pair to rtr state; error " +
+                  std::to_string(err));
+    }
+  }
+
+  void rts() {
+    ibv_qp_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTS;
+    attr.sq_psn = 4242;
+    attr.timeout = 17;  // 0.5s
+    attr.retry_cnt = 7;
+    attr.rnr_retry = 7;
+    attr.max_rd_atomic = 1;
+    int err = ibv_modify_qp(qp, &attr,
+                            IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
+                                IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+                                IBV_QP_MAX_QP_RD_ATOMIC);
+    if (err) {
+      throw Error("Failed to move queue pair to rts state; error " +
+                  std::to_string(err));
+    }
+  }
+
+  void read(MemoryRegion& dstmr,
+            void* dstbuf,
+            uint32_t rkey,
+            uintptr_t remoteAddress,
+            size_t length) {
+
+    ibv_sge sg;
+    ibv_send_wr wr;
+    ibv_send_wr* bad_wr;
+
+    memset(&sg, 0, sizeof(sg));
+    sg.addr = (uintptr_t)dstbuf;
+    sg.length = length;
+    sg.lkey = dstmr.lkey();
+
+    memset(&wr, 0, sizeof(wr));
+    wr.wr_id = 0;
+    wr.sg_list = &sg;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_RDMA_READ;
+    wr.send_flags = IBV_SEND_SIGNALED;
+    wr.wr.rdma.remote_addr = remoteAddress;
+    wr.wr.rdma.rkey = rkey;
+
+    ibv_qp_attr qattr;
+    ibv_qp_init_attr qiattr;
+
+    if (ibv_query_qp(qp, &qattr, IBV_QP_STATE, &qiattr)) {
+      throw Error("Failed to query qp");
+    }
+
+    int err = ibv_post_send(qp, &wr, &bad_wr);
+    if (err) {
+      throw Error("RDMA read failed; error " + std::to_string(err));
+    }
+  }
+};
+
+}  // namespace ib
+
+namespace rdma {
+
+struct ibBuffer : Buffer {
+  std::optional<ib::MemoryRegion> mr;
+  virtual ~ibBuffer() override {
+  }
+  virtual uint32_t key() override {
+    return mr->rkey();
+  }
+  virtual uint32_t keyFor(Endpoint ep) override {
+    return mr->rkey();
+  }
+};
+
+struct ibCompletionQueue : CompletionQueue {
+  ib::CompletionQueue cq;
+  virtual ~ibCompletionQueue() {
+  }
+  ibCompletionQueue(ib::Context& ctx, int size)
+      : cq(ctx, size) {
+  }
+  virtual void wait() override {
+    cq.wait();
+  }
+};
+
+struct ibMultiBuffer : Buffer {
+  std::deque<ib::MemoryRegion> mrs;
+  std::vector<uint32_t> lids;
+  virtual ~ibMultiBuffer() override {
+  }
+  virtual uint32_t key() override {
+    std::abort();
+  }
+  ib::MemoryRegion& mrFor(Endpoint ep) {
+    for (size_t i = 0; i != lids.size(); ++i) {
+      if (lids[i] == ep.lid) {
+        return mrs.at(i);
+      }
+    }
+    throw Error("Endpoint not found for multibuffer");
+  }
+  virtual uint32_t keyFor(Endpoint ep) override {
+    return mrFor(ep).rkey();
+  }
+};
+
+struct ibHost : Host {
+  ib::Context* context = nullptr;
+  ib::ProtectionDomain* pd = nullptr;
+  std::optional<ib::Port> port;
+  ib::CompletionQueue* cq = nullptr;
+  std::optional<ib::QueuePair> qp;
+  bool inRts = false;
+  virtual ~ibHost() override {
+  }
+  ibHost(ib::Context* context, ib::ProtectionDomain* pd)
+      : context(context)
+      , pd(pd) {
+    if (context->ports.empty()) {
+      throw ib::Error("Infiniband device has no ports!");
+    }
+    port = context->ports.at(0);
+    // printf("Host using %d:%d\n", port->lid(), port->num);
+  }
+  virtual Endpoint init(CompletionQueue& cqa) override {
+    cq = &((ibCompletionQueue&)cqa).cq;
+    qp.emplace(*pd, *cq);
+    qp->init(*port, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ);
+    inRts = false;
+    // printf("QP %d:%d\n", port->lid(), qp->num());
+    return {port->lid(), qp->num(), port->gid()};
+  }
+  virtual void connect(Endpoint ep) override {
+    qp->rtr(*port, ep.lid, ep.qpnum, ep.gid);
+    inRts = false;
+  }
+  virtual void read(Buffer& localBuffer,
+                    void* localAddress,
+                    uint32_t remoteKey,
+                    uintptr_t remoteAddress,
+                    size_t size) override {
+    if (!inRts) {
+      qp->rts();
+      inRts = true;
+    }
+    if (auto buf = dynamic_cast<ibBuffer*>(&localBuffer)) {
+      qp->read(*buf->mr, localAddress, remoteKey, remoteAddress, size);
+    } else if (auto buf = dynamic_cast<ibMultiBuffer*>(&localBuffer)) {
+      qp->read(buf->mrFor(Endpoint{port->lid(), qp->num(), port->gid()}),
+               localAddress, remoteKey, remoteAddress, size);
+    }
+  }
+  virtual void wait() override {
+    cq->wait();
+  }
+};
+
+struct ibContext : Context {
+  ib::Device device;
+  std::optional<ib::Context> context;
+  std::optional<ib::ProtectionDomain> pd;
+  ibContext(ib::Device device)
+      : device(device) {
+    context.emplace(device);
+    pd.emplace(*context);
+  }
+  virtual ~ibContext() override {
+  }
+  virtual std::unique_ptr<Host> createHost() override {
+    return std::make_unique<ibHost>(&*context, &*pd);
+  }
+  virtual std::unique_ptr<Buffer> createBuffer(void* address,
+                                               size_t size) override {
+    auto r = std::make_unique<ibBuffer>();
+    r->mr.emplace(
+        *pd, address, size, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ);
+    return r;
+  }
+  virtual std::unique_ptr<CompletionQueue> createCQ(int size) override {
+    return std::make_unique<ibCompletionQueue>(*context, size);
+  }
+};
+
+struct ibMultiCompletionQueue : CompletionQueue {
+  std::vector<std::shared_ptr<ibCompletionQueue>> cqs;
+  virtual ~ibMultiCompletionQueue() override {
+  }
+  virtual void wait() override {
+    std::abort();
+  }
+};
+
+struct ibMultiHost : ibHost {
+  size_t index;
+  ibMultiHost(size_t index, ib::Context* context, ib::ProtectionDomain* pd)
+      : ibHost(context, pd)
+      , index(index) {
+  }
+  virtual ~ibMultiHost() override {
+  }
+  virtual Endpoint init(CompletionQueue& cqa) override {
+    auto cq = (ibMultiCompletionQueue&)cqa;
+    return ibHost::init(*cq.cqs.at(index));
+  }
+};
+
+struct ibMultiContext : Context {
+  ib::DeviceList devlist;
+  std::deque<ibContext> contexts;
+  std::minstd_rand rng;
+  ibMultiContext() {
+    if (devlist.empty()) {
+      throw ib::Error("No infiniband devices found");
+    }
+    rng.seed(std::random_device{}());
+    for (auto& v : devlist) {
+      contexts.emplace_back(v);
+    }
+  }
+  virtual ~ibMultiContext() override {
+  }
+  virtual std::unique_ptr<Host> createHost() override {
+    size_t index =
+        std::uniform_int_distribution<size_t>(0, contexts.size() - 1)(rng);
+    auto& ctx = contexts[index];
+    return std::make_unique<ibMultiHost>(index, &*ctx.context, &*ctx.pd);
+  }
+  virtual std::unique_ptr<Buffer> createBuffer(void* address,
+                                               size_t size) override {
+    auto r = std::make_unique<ibMultiBuffer>();
+    for (auto& ctx : contexts) {
+      r->mrs.emplace_back(*ctx.pd, address, size,
+                          IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ);
+      r->lids.push_back(ctx.context->ports.at(0).lid());
+    }
+    return r;
+  }
+  virtual std::unique_ptr<CompletionQueue> createCQ(int size) override {
+    auto r = std::make_unique<ibMultiCompletionQueue>();
+    for (auto& ctx : contexts) {
+      r->cqs.push_back(std::make_unique<ibCompletionQueue>(*ctx.context, size));
+    }
+    return r;
+  }
+};
+
+std::unique_ptr<Context> create() {
+  return std::make_unique<ibMultiContext>();
+}
+
+}  // namespace rdma

--- a/src/distributed/network.cc
+++ b/src/distributed/network.cc
@@ -658,13 +658,17 @@ class ServerImpl : public Ref<ServerImpl> {
   }
 
   void bind(std::string_view endpoint) {
-    if (endpoint.empty())
+    if (endpoint.empty()) {
       return;
+    }
     bound = true;
     auto [hostname, port] = decodeEndpoint(endpoint);
 
     asio::error_code ec;
-    asio::ip::address address = asio::ip::make_address(hostname, ec);
+    asio::ip::address address;
+    if (hostname != "*") {
+      address = asio::ip::make_address(hostname, ec);
+    }
     if (ec) {
       auto resolver = resolverCache.make(context);
       (*resolver)->async_resolve(

--- a/src/distributed/network.cc
+++ b/src/distributed/network.cc
@@ -1,0 +1,891 @@
+
+#include "network.h"
+
+#include "asio.hpp"
+
+#include <deque>
+#include <list>
+#include <vector>
+
+namespace network {
+
+template <typename T> struct Handle {
+  T* obj = nullptr;
+  Handle() {
+  }
+  Handle(T& obj)
+      : obj(&obj) {
+    ++obj.refcount;
+  }
+  Handle(std::nullptr_t) {
+  }
+  Handle(Handle&& n) {
+    obj = std::exchange(n.obj, nullptr);
+  }
+  Handle(const Handle& n) {
+    acquire(n.obj);
+  }
+  Handle& operator=(Handle&& n) {
+    std::swap(obj, n.obj);
+    return *this;
+  }
+  Handle& operator=(const Handle& n) {
+    acquire(n.obj);
+    return *this;
+  }
+  void acquire(T* newobj) {
+    release();
+    obj = newobj;
+    if (obj)
+      ++obj->refcount;
+  }
+  void release() {
+    if (obj) {
+      if (--obj->refcount == 0) {
+        obj->owner->free(obj);
+      }
+      obj = nullptr;
+    }
+  }
+  ~Handle() {
+    release();
+  }
+  T& operator*() const {
+    return *obj;
+  }
+  T* operator->() const {
+    return obj;
+  }
+  explicit operator bool() const {
+    return obj;
+  }
+};
+
+template <typename T> struct Ref {
+  std::atomic_int refcount = 0;
+  Handle<T> ref() {
+    return *(T*)this;
+  }
+};
+
+template <typename T> struct Cache {
+  struct entry {
+    entry* freenext = nullptr;
+    Cache* owner = nullptr;
+    std::aligned_storage_t<sizeof(T), alignof(T)> buf;
+    entry* storagenext = nullptr;
+  };
+  std::atomic<entry*> storagelist;
+  std::atomic<entry*> freelist;
+  static entry* get(T* ptr) {
+    uintptr_t v = (uintptr_t)(void*)ptr;
+    v -= offsetof(entry, buf);
+    return (entry*)v;
+  }
+  template <typename... A> T* allocate(A&&... args) {
+    T* r;
+    entry* e = freelist;
+    while (e && !freelist.compare_exchange_weak(e, e->freenext))
+      ;
+    if (!e) {
+      e = new entry();
+      entry* s = storagelist;
+      do {
+        e->storagenext = s;
+      } while (!storagelist.compare_exchange_weak(s, e));
+    }
+    r = (T*)&e->buf;
+    new (r) T(std::forward<A>(args)...);
+    e->owner = this;
+    return r;
+  }
+  void free(T* obj) {
+    entry* e = get(obj);
+    if (e->owner != this) {
+      std::terminate();
+    }
+    e->owner = nullptr;
+    obj->~T();
+    entry* f = freelist;
+    do {
+      e->freenext = f;
+    } while (!freelist.compare_exchange_weak(f, e));
+  }
+
+  ~Cache() {
+    for (entry* e = storagelist; e; e = e->storagenext) {
+      if (e->owner) {
+        ((T&)e->buf).~T();
+      }
+    }
+  }
+
+  template <typename... A> Handle<T> make(A&&... args) {
+    return (allocate(this, std::forward<A>(args)...))->ref();
+  }
+};
+
+template <typename T> struct Wrapper : Ref<Wrapper<T>> {
+  Cache<Wrapper<T>>* owner = nullptr;
+  T obj;
+  template <typename... A>
+  Wrapper(Cache<Wrapper<T>>* owner, A&&... args)
+      : owner(owner)
+      , obj(std::forward<A>(args)...) {
+  }
+  T* operator->() {
+    return &obj;
+  }
+  T& operator*() {
+    return obj;
+  }
+};
+
+template <size_t maxsize> struct Buffer : Ref<Buffer<maxsize>> {
+  Cache<Buffer>* owner = nullptr;
+  std::array<char, maxsize> buf;
+  size_t begin = 0;
+  size_t end = 0;
+  Buffer(Cache<Buffer>* owner)
+      : owner(owner) {
+  }
+  size_t space() {
+    return buf.size() - end;
+  }
+  size_t append(const void* data, size_t n) {
+    n = std::min(n, space());
+    std::memcpy(buf.data() + end, data, n);
+    end += n;
+    return n;
+  }
+  void free(size_t n) {
+    begin += n;
+  }
+  const void* data() const {
+    return buf.data() + begin;
+  }
+  size_t size() const {
+    return end - begin;
+  }
+  bool empty() const {
+    return size() == 0;
+  }
+};
+
+std::pair<std::string_view, int> decodeEndpoint(std::string_view endpoint) {
+  std::string_view hostname = endpoint;
+  int port = 0;
+  auto bpos = endpoint.find('[');
+  if (bpos != std::string_view::npos) {
+    auto bepos = endpoint.find(']', bpos);
+    if (bepos != std::string_view::npos) {
+      hostname = endpoint.substr(bpos + 1, bepos - (bpos + 1));
+      endpoint = endpoint.substr(bepos + 1);
+    }
+  }
+  auto cpos = endpoint.find(':');
+  if (cpos != std::string_view::npos) {
+    if (hostname == endpoint)
+      hostname = endpoint.substr(0, cpos);
+    ++cpos;
+    while (cpos != endpoint.size()) {
+      char c = endpoint[cpos];
+      if (c < '0' || c > '9')
+        break;
+      port *= 10;
+      port += c - '0';
+      ++cpos;
+    }
+  }
+  return {hostname, port};
+}
+
+class PeerImpl : public Ref<PeerImpl> {
+ public:
+  Cache<PeerImpl>* owner = nullptr;
+  asio::io_context& context;
+  Cache<Wrapper<asio::ip::tcp::resolver>> resolverCache;
+  Cache<Wrapper<asio::steady_timer>> timerCache;
+  Cache<Wrapper<asio::ip::tcp::socket>> socketCache;
+  Cache<Buffer<0x10000>> bufferCache;
+  asio::ip::tcp::socket socket;
+  std::string connectEndpoint;
+  std::string remoteHost;
+  int remotePort = 0;
+  bool connected = false;
+  bool closed = false;
+  std::vector<char> readBuffer;
+  Handle<Buffer<0x10000>> writeBuffer;
+  std::vector<Handle<Buffer<0x10000>>> writeBufferQueue;
+  std::mutex mutex;
+  PeerImpl(Cache<PeerImpl>* owner, asio::io_context& context)
+      : owner(owner)
+      , context(context)
+      , socket(context) {
+  }
+  void connect(std::string_view endpoint) {
+    auto l = lock();
+    if (connected)
+      return;
+    if (endpoint.empty())
+      return;
+    if (connectEndpoint != endpoint)
+      connectEndpoint = endpoint;
+    auto [hostname, port] = decodeEndpoint(endpoint);
+
+    remoteHost = hostname;
+    remotePort = port;
+
+    asio::error_code ec;
+    asio::ip::address address = asio::ip::make_address(hostname, ec);
+    if (ec) {
+      auto resolver = resolverCache.make(context);
+      (*resolver)->async_resolve(
+          remoteHost, "",
+          [this, str = std::string(remoteHost), peer = ref(), resolver,
+           port = port](const asio::error_code& ec,
+                        asio::ip::tcp::resolver::results_type results) mutable {
+            if (!ec) {
+              int n = 0;
+              for (auto ep : results) {
+                auto timer = timerCache.make(context);
+                (*timer)->expires_from_now(std::chrono::seconds(n));
+                (*timer)->async_wait(
+                    [ep, timer, peer, port](const asio::error_code& ec) {
+                      if (!ec) {
+                        peer->connect(
+                            {ep.endpoint().address(), (unsigned short)port});
+                      }
+                    });
+                ++n;
+              }
+            } else {
+              printf("resolve(%s): %s\n", str.c_str(), ec.message().c_str());
+            }
+          });
+    } else {
+      connect({address, (unsigned short)port});
+    }
+
+    auto timer = timerCache.make(context);
+    (*timer)->expires_from_now(std::chrono::seconds(30));
+    (*timer)->async_wait(
+        [this, timer, peer = ref()](const asio::error_code& ec) {
+          if (!ec) {
+            connect(connectEndpoint);
+          }
+        });
+  }
+
+  void asyncRead(size_t offset = 0) {
+    socket.async_receive(
+        asio::buffer(readBuffer.data() + offset, readBuffer.size() - offset),
+        [this, peer = ref()](auto&&... args) mutable {
+          onReceive(std::forward<decltype(args)>(args)...);
+        });
+  }
+
+  void setConnected(asio::ip::tcp::socket sock) {
+    if (connected)
+      return;
+    if (closed) {
+      sock.close();
+      return;
+    }
+    connected = true;
+    socket = std::move(sock);
+
+    if (onReceiveCallback || onMessageCallback)
+      asyncRead();
+    flush();
+  }
+
+  void connect(asio::ip::tcp::endpoint ep) {
+    if (connected || closed)
+      return;
+
+    auto h = socketCache.make(context);
+
+    (*h)->async_connect(
+        ep, [this, ep, h, peer = ref()](const asio::error_code& ec) {
+          auto l = lock();
+          if (!ec && !connected) {
+            setConnected(std::move(**h));
+          } else if (ec) {
+            printf("connect(%s:%d): %s\n", ep.address().to_string().c_str(),
+                   (int)ep.port(), ec.message().c_str());
+          }
+        });
+  }
+
+  void failure() {
+    auto l = lock();
+    if (!connected)
+      return;
+    connected = false;
+    socket.close();
+    writeBuffer = nullptr;
+    CallbackCounter cc(activeCallbacks);
+    l.unlock();
+    if (onConnectionClosed) {
+      onConnectionClosed();
+    }
+    auto timer = timerCache.make(context);
+    (*timer)->expires_from_now(std::chrono::seconds(5));
+    (*timer)->async_wait(
+        [this, timer, peer = ref()](const asio::error_code& ec) {
+          if (!ec) {
+            connect(connectEndpoint);
+          }
+        });
+  }
+
+  std::atomic<bool> sending = false;
+
+  std::vector<char> sendBuffer;
+
+  void callSend(std::vector<char> buffer, size_t offset) {
+    auto ab = asio::buffer(buffer.data() + offset, buffer.size() - offset);
+    socket.async_send(
+        ab, [this, peer = ref(), buffer = std::move(buffer), offset](
+                const asio::error_code& ec, size_t n) mutable {
+          if (ec) {
+            sending = false;
+            failure();
+          } else {
+            size_t remaining = buffer.size() - offset - n;
+            if (remaining) {
+              auto l = lock();
+              callSend(std::move(buffer), offset + n);
+            } else {
+              sending = false;
+              auto l = lock();
+              flush();
+            }
+          }
+        });
+  }
+
+  void flush() {
+    if (!connected)
+      return;
+    if (!sendBuffer.empty()) {
+      if (sending.exchange(true))
+        return;
+      callSend(std::move(sendBuffer), 0);
+      sendBuffer.clear();
+    }
+  }
+
+  void sendNoFlush(const void* data, size_t n) {
+    size_t offset = sendBuffer.size();
+    if (offset + n > sendBuffer.capacity()) {
+      sendBuffer.reserve(std::max(offset + n, offset * 2));
+    }
+    sendBuffer.resize(offset + n);
+    std::memcpy(sendBuffer.data() + offset, data, n);
+  }
+
+  //  std::vector<asio::const_buffer> sendBuffers;
+  //
+  //  void flush() {
+  //    if (!connected) return;
+  //    if (sending) return;
+  //    sendBuffers.clear();
+  //    if (!writeBufferQueue.empty()) {
+  //      for (auto& v : writeBufferQueue) {
+  //        sendBuffers.push_back(asio::buffer(v->data(), v->size()));
+  //      }
+  //      writeBufferQueue.clear();
+  //    }
+  //    size_t freeN = 0;
+  //    if (writeBuffer && !writeBuffer->empty()) {
+  //      sendBuffers.push_back(asio::buffer(writeBuffer->data(),
+  //      writeBuffer->size())); freeN = writeBuffer->size();
+  //    }
+  //    if (!sendBuffers.empty()) {
+  //      sending = true;
+  //      socket.async_send(sendBuffers, [this, freeSrc = writeBuffer->ref(),
+  //      freeN, peer = ref()](const asio::error_code& ec, size_t n) {
+  //        sending = false;
+  //        freeSrc->free(freeN);
+  //        if (ec) {
+  //          failure();
+  //        } else {
+  //          flush();
+  //        }
+  //      });
+  //    }
+  //  }
+
+  //  void sendNoFlush(const void* data, size_t n) {
+  //    if (!writeBuffer || writeBuffer->space() == 0) {
+  //      writeBuffer = bufferCache.make();
+  //    }
+  //    size_t s = writeBuffer->append(data, n);
+  //    while (writeBuffer->space() == 0) {
+  //      writeBufferQueue.push_back(writeBuffer);
+  //      writeBuffer = bufferCache.make();
+  //      data = (const char*)data + s;
+  //      n -= s;
+  //      s = writeBuffer->append(data, n);
+  //    }
+  //  }
+
+  void send(const void* data, size_t n) {
+    auto l = lock();
+    sendNoFlush(data, n);
+    if (!sending) {
+      flush();
+    }
+  }
+
+  void sendMessage(const void* data, size_t n) {
+    auto l = lock();
+    uint32_t len = n;
+    sendNoFlush(&len, sizeof(len));
+    sendNoFlush(data, n);
+    flush();
+  }
+
+  struct CallbackCounter {
+    std::atomic_int& c;
+    CallbackCounter(std::atomic_int& c)
+        : c(c) {
+      ++c;
+    }
+    ~CallbackCounter() {
+      --c;
+    }
+  };
+  std::atomic_int activeCallbacks;
+
+  std::function<void()> onConnectionClosed;
+  std::function<void(const void*, size_t)> onReceiveCallback;
+  std::function<void(const void*, size_t)> onMessageCallback;
+
+  void setOnReceive(std::function<void(const void*, size_t)> callback,
+                    size_t bufferSize = 0x10000) {
+    auto l = lock();
+    if (!onReceiveCallback && connected) {
+      asyncRead();
+    }
+    readBuffer.resize(bufferSize);
+    onReceiveCallback = std::move(callback);
+  }
+
+  int messageState = -1;
+  size_t messageReceived = 0;
+  size_t messageLength = 0;
+
+  void setOnMessage(std::function<void(const void*, size_t)> callback,
+                    size_t bufferSize = 0x10000) {
+    auto l = lock();
+    if (!onMessageCallback && callback) {
+      if (connected) {
+        asyncRead();
+      }
+      readBuffer.resize(bufferSize);
+      messageState = 0;
+    }
+    if (!callback) {
+      messageState = -1;
+    }
+    onMessageCallback = std::move(callback);
+  }
+
+  void onReceive(const asio::error_code& ec, size_t n) {
+    auto l = lock();
+    if (closed) {
+      return;
+    }
+    CallbackCounter cc(activeCallbacks);
+    if (!ec) {
+      while (true) {
+        if (messageState == 0) {
+          messageReceived += n;
+          n = 0;
+          if (messageReceived >= 4) {
+            messageLength = *(uint32_t*)readBuffer.data();
+            readBuffer.resize(std::max(readBuffer.size(), 4 + messageLength));
+            messageState = 1;
+            continue;
+          } else {
+            asyncRead(messageReceived);
+          }
+        } else if (messageState == 1) {
+          messageReceived += n;
+          n = 0;
+          if (messageReceived >= 4 + messageLength) {
+            std::vector<char> tmp(
+                readBuffer.data() + 4, readBuffer.data() + 4 + messageLength);
+            if (messageReceived == 4 + messageLength) {
+              messageState = 0;
+              messageReceived = 0;
+              asyncRead(messageReceived);
+              l.unlock();
+            } else {
+              std::memmove(readBuffer.data(),
+                           readBuffer.data() + 4 + messageLength,
+                           messageReceived - (4 + messageLength));
+              messageReceived -= 4 + messageLength;
+              messageState = 0;
+              l.unlock();
+              context.post([this]() { onReceive({}, 0); });
+            }
+            onMessageCallback(tmp.data(), tmp.size());
+            break;
+          } else {
+            if (readBuffer.size() - messageReceived == 0) {
+              readBuffer.resize(readBuffer.size() * 2);
+            }
+          }
+          asyncRead(messageReceived);
+        } else if (onReceiveCallback) {
+          asyncRead();
+          if (n) {
+            l.unlock();
+            onReceiveCallback(readBuffer.data(), n);
+          }
+        }
+        break;
+      }
+    } else {
+      l.unlock();
+      failure();
+    }
+  }
+
+  std::unique_lock<std::mutex> lock() {
+    return std::unique_lock(mutex);
+  }
+
+  void close() {
+    auto l = lock();
+    if (connected) {
+      connected = false;
+      socket.close();
+      writeBuffer = nullptr;
+    }
+
+    messageState = -1;
+    closed = true;
+
+    l.unlock();
+    while (activeCallbacks) {
+      std::this_thread::yield();
+    }
+  }
+
+  void post_close() {
+    context.post([peer = ref()] { peer->close(); });
+  }
+
+  void setOnConnectionClosed(std::function<void()> callback) {
+    onConnectionClosed = std::move(callback);
+  }
+};
+
+class ServerImpl : public Ref<ServerImpl> {
+ public:
+  Cache<ServerImpl>* owner = nullptr;
+  asio::io_context& context;
+  Cache<Wrapper<asio::ip::tcp::resolver>> resolverCache;
+  Cache<Wrapper<asio::steady_timer>> timerCache;
+  Cache<Wrapper<asio::ip::tcp::acceptor>> acceptorCache;
+  Cache<Wrapper<asio::ip::tcp::socket>> socketCache;
+  Cache<PeerImpl> peerCache;
+  std::string listenEndpoint;
+  std::function<void(Handle<PeerImpl> peer)> onPeer;
+  bool bound = false;
+  std::vector<Handle<Wrapper<asio::ip::tcp::socket>>> sockets;
+  std::mutex mutex;
+  ServerImpl(Cache<ServerImpl>* owner, asio::io_context& context)
+      : owner(owner)
+      , context(context) {
+  }
+  ~ServerImpl() {
+    close();
+  }
+
+  void asyncAccept(Handle<Wrapper<asio::ip::tcp::acceptor>> h,
+                   Handle<Wrapper<asio::ip::tcp::socket>> socket) {
+    (*h)->async_accept(**socket, [this, server = ref(), h,
+                                  socket](const asio::error_code& ec) {
+      if (!ec) {
+        if (onPeer) {
+          auto peer = peerCache.make(context);
+          peer->setConnected(std::move(**socket));
+          onPeer(peer);
+        }
+      }
+      asyncAccept(h, socket);
+    });
+  }
+
+  void bind(asio::ip::tcp::endpoint ep) {
+    auto retry = [&](asio::error_code ec) {
+      printf("bind(%s:%d): %s\n", ep.address().to_string().c_str(),
+             (int)ep.port(), ec.message().c_str());
+      auto timer = timerCache.make(context);
+      (*timer)->expires_from_now(std::chrono::seconds(30));
+      (*timer)->async_wait(
+          [this, ep, timer, server = ref()](const asio::error_code& ec) {
+            if (!ec) {
+              bind(ep);
+            }
+          });
+    };
+
+    auto h = acceptorCache.make(context);
+
+    asio::error_code ec;
+    (*h)->open(ep.protocol());
+    (*h)->set_option(asio::socket_base::reuse_address(true));
+    (*h)->bind(ep, ec);
+    if (ec)
+      return retry(ec);
+    (*h)->listen(asio::socket_base::max_connections, ec);
+    if (ec)
+      return retry(ec);
+
+    auto socket = socketCache.make(context);
+
+    asyncAccept(h, socket);
+
+    auto l = lock();
+    sockets.push_back(socket);
+  }
+
+  void bind(std::string_view endpoint) {
+    if (endpoint.empty())
+      return;
+    bound = true;
+    auto [hostname, port] = decodeEndpoint(endpoint);
+
+    asio::error_code ec;
+    asio::ip::address address = asio::ip::make_address(hostname, ec);
+    if (ec) {
+      auto resolver = resolverCache.make(context);
+      (*resolver)->async_resolve(
+          hostname, "",
+          [this, peer = ref(), resolver, port = port](
+              const asio::error_code& ec,
+              asio::ip::tcp::resolver::results_type results) mutable {
+            if (!ec) {
+              for (auto ep : results) {
+                bind({ep.endpoint().address(), (unsigned short)port});
+              }
+            } else {
+              auto timer = timerCache.make(context);
+              (*timer)->expires_from_now(std::chrono::seconds(30));
+              (*timer)->async_wait(
+                  [this, timer, peer = ref()](const asio::error_code& ec) {
+                    if (!ec) {
+                      auto l = lock();
+                      bind(listenEndpoint);
+                    }
+                  });
+            }
+          });
+    } else {
+      context.post([this, address, port = port, server = ref()] {
+        bind({address, (unsigned short)port});
+      });
+    }
+  }
+
+  void listen(std::string_view endpoint) {
+    auto l = lock();
+    listenEndpoint = endpoint;
+
+    if (onPeer)
+      bind(endpoint);
+  }
+
+  void setOnPeer(std::function<void(Handle<PeerImpl>)> callback) {
+    auto l = lock();
+    onPeer = callback;
+    if (!bound)
+      bind(listenEndpoint);
+  }
+
+  std::unique_lock<std::mutex> lock() {
+    return std::unique_lock(mutex);
+  }
+
+  void close() {
+    auto l = lock();
+    onPeer = nullptr;
+    for (auto& v : sockets) {
+      (*v)->close();
+    }
+    sockets.clear();
+  }
+};
+
+class NetworkImpl {
+ public:
+  Cache<PeerImpl> peerCache;
+  Cache<ServerImpl> serverCache;
+  asio::io_context context;
+  asio::executor_work_guard<asio::io_context::executor_type> work{
+      context.get_executor()};
+
+  ~NetworkImpl() {
+    work.reset();
+  }
+
+  Handle<PeerImpl> connect(std::string_view endpoint) {
+    auto h = peerCache.make(context);
+    h->connect(endpoint);
+    return h;
+  }
+
+  Handle<ServerImpl> listen(std::string_view endpoint) {
+    auto h = serverCache.make(context);
+    h->listen(endpoint);
+    return h;
+  }
+
+  template <typename T>
+  static std::unique_ptr<T, std::function<void(T*)>> wrap(Handle<T> h) {
+    auto* ptr = &*h;
+    return std::unique_ptr<T, std::function<void(T*)>>(
+        ptr, [h = std::move(h)](T* ptr) mutable { h = nullptr; });
+  }
+
+  bool run_one() {
+    return context.run_one() != 0;
+  }
+
+  void post(std::function<void()> f) {
+    asio::post(std::move(f));
+  }
+};
+
+Peer::Peer(std::unique_ptr<PeerImpl, std::function<void(PeerImpl*)>> impl)
+    : impl(std::move(impl)) {
+}
+
+Peer::~Peer() {
+}
+
+void Peer::send(const void* data, size_t n) {
+  return impl->send(data, n);
+}
+
+void Peer::send(std::string_view buf) {
+  return send(buf.data(), buf.size());
+}
+
+void Peer::setOnReceive(std::function<void(const void*, size_t)> callback) {
+  return impl->setOnReceive(std::move(callback));
+}
+
+void Peer::setOnReceive(std::function<void(std::string_view)> callback) {
+  setOnReceive([callback = std::move(callback)](const void* data, size_t n) {
+    return callback(std::string_view((const char*)data, n));
+  });
+}
+
+void Peer::sendMessage(const void* data, size_t n) {
+  return impl->sendMessage(data, n);
+}
+
+void Peer::sendMessage(std::string_view buf) {
+  return sendMessage(buf.data(), buf.size());
+}
+
+void Peer::setOnMessage(std::function<void(const void*, size_t)> callback) {
+  return impl->setOnMessage(std::move(callback));
+}
+
+void Peer::setOnMessage(std::function<void(std::string_view)> callback) {
+  if (!callback)
+    setOnMessage(nullptr);
+  else
+    setOnMessage([callback = std::move(callback)](const void* data, size_t n) {
+      return callback(std::string_view((const char*)data, n));
+    });
+}
+
+void Peer::setOnMessage(std::nullptr_t) {
+  impl->setOnMessage(nullptr);
+}
+
+void Peer::setOnConnectionClosed(std::function<void()> callback) {
+  impl->setOnConnectionClosed(std::move(callback));
+}
+
+bool Peer::connected() const {
+  return impl->connected;
+}
+
+void Peer::close() {
+  impl->close();
+}
+
+void Peer::post_close() {
+  impl->post_close();
+}
+
+std::unique_lock<std::mutex> Peer::lock() {
+  return impl->lock();
+}
+
+Server::Server(
+    std::unique_ptr<ServerImpl, std::function<void(ServerImpl*)>> impl)
+    : impl(std::move(impl)) {
+}
+
+Server::~Server() {
+}
+
+void Server::setOnPeer(std::function<void(Peer)> callback) {
+  impl->setOnPeer([callback = std::move(callback)](Handle<PeerImpl> peer) {
+    callback(NetworkImpl::wrap(peer));
+  });
+}
+
+void Server::close() {
+  impl->close();
+}
+
+std::unique_lock<std::mutex> Server::lock() {
+  return impl->lock();
+}
+
+void Server::listen(std::string_view endpoint) {
+  return impl->listen(endpoint);
+}
+
+Network::Network() {
+  impl = std::make_unique<NetworkImpl>();
+}
+
+Network::Network(
+    std::unique_ptr<NetworkImpl, std::function<void(NetworkImpl*)>> impl)
+    : impl(std::move(impl)) {
+}
+
+Network::~Network() {
+}
+
+Peer Network::connect(std::string_view endpoint) {
+  return impl->wrap(impl->connect(endpoint));
+}
+
+Server Network::listen(std::string_view endpoint) {
+  return impl->wrap(impl->listen(endpoint));
+}
+
+bool Network::run_one() {
+  return impl->run_one();
+}
+
+void Network::post(std::function<void()> f) {
+  return impl->post(std::move(f));
+}
+
+}  // namespace network

--- a/src/distributed/network.h
+++ b/src/distributed/network.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string_view>
+
+namespace network {
+
+class PeerImpl;
+class ServerImpl;
+class NetworkImpl;
+
+class Peer {
+ public:
+  Peer() = default;
+  Peer(Peer&&) = default;
+  Peer(std::unique_ptr<PeerImpl, std::function<void(PeerImpl*)>> impl);
+  ~Peer();
+  Peer& operator=(Peer&&) = default;
+
+  void send(const void* data, size_t n);
+  void send(std::string_view buf);
+
+  void setOnReceive(std::function<void(const void* data, size_t n)> callback);
+  void setOnReceive(std::function<void(std::string_view)> callback);
+
+  void sendMessage(const void* data, size_t n);
+  void sendMessage(std::string_view buf);
+
+  void setOnMessage(std::function<void(const void* data, size_t n)> callback);
+  void setOnMessage(std::function<void(std::string_view)> callback);
+  void setOnMessage(std::nullptr_t);
+
+  void setOnConnectionClosed(std::function<void()> callback);
+
+  explicit operator bool() const {
+    return impl != nullptr;
+  }
+
+  bool connected() const;
+  void close();
+  void post_close();
+
+  std::unique_lock<std::mutex> lock();
+
+ private:
+  std::unique_ptr<PeerImpl, std::function<void(PeerImpl*)>> impl;
+};
+
+class Server {
+ public:
+  Server() = default;
+  Server(Server&&) = default;
+  Server(std::unique_ptr<ServerImpl, std::function<void(ServerImpl*)>> impl);
+  ~Server();
+  Server& operator=(Server&&) = default;
+
+  void setOnPeer(std::function<void(Peer)> callback);
+  void close();
+  std::unique_lock<std::mutex> lock();
+  void listen(std::string_view endpoint);
+
+ private:
+  std::unique_ptr<ServerImpl, std::function<void(ServerImpl*)>> impl;
+};
+
+class Network {
+ public:
+  Network();
+  Network(Network&&) = default;
+  Network(std::unique_ptr<NetworkImpl, std::function<void(NetworkImpl*)>> impl);
+  ~Network();
+
+  Peer connect(std::string_view endpoint);
+  Server listen(std::string_view endpoint);
+
+  bool run_one();
+  void post(std::function<void()> f);
+
+ private:
+  std::unique_ptr<NetworkImpl, std::function<void(NetworkImpl*)>> impl;
+};
+
+}  // namespace network

--- a/src/distributed/rdma.h
+++ b/src/distributed/rdma.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+
+namespace rdma {
+
+class Error : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+struct Endpoint {
+  uint32_t lid;
+  uint32_t qpnum;
+  std::array<std::byte, 16> gid;
+  bool operator==(const Endpoint& n) {
+    return lid == n.lid && qpnum == n.qpnum;
+  }
+  bool operator!=(const Endpoint& n) {
+    return !(*this == n);
+  }
+};
+
+struct Buffer {
+  virtual ~Buffer() {
+  }
+  virtual uint32_t key() = 0;
+  virtual uint32_t keyFor(Endpoint ep) = 0;
+};
+
+struct CompletionQueue {
+  virtual ~CompletionQueue() {
+  }
+  virtual void wait() = 0;
+};
+
+struct Host {
+  virtual ~Host() {
+  }
+  virtual Endpoint init(CompletionQueue& cq) = 0;
+  virtual void connect(Endpoint ep) = 0;
+
+  virtual void read(Buffer& localBuffer,
+                    void* localAddress,
+                    uint32_t remoteKey,
+                    uintptr_t remoteAddress,
+                    size_t size) = 0;
+  virtual void wait() = 0;
+};
+
+struct Context {
+  virtual ~Context() {
+  }
+  virtual std::unique_ptr<Host> createHost() = 0;
+  virtual std::unique_ptr<Buffer> createBuffer(void* address, size_t size) = 0;
+  virtual std::unique_ptr<CompletionQueue> createCQ(int size) = 0;
+};
+
+std::unique_ptr<Context> create();
+
+}  // namespace rdma

--- a/src/distributed/rdma_nop.cc
+++ b/src/distributed/rdma_nop.cc
@@ -1,0 +1,9 @@
+#include "rdma.h"
+
+namespace rdma {
+
+std::unique_ptr<Context> create() {
+  return nullptr;
+}
+
+}  // namespace rdma

--- a/src/distributed/rpc.h
+++ b/src/distributed/rpc.h
@@ -1,0 +1,609 @@
+
+#define ZSTD_STATIC_LINKING_ONLY
+#include "zstd/lib/zstd.h"
+
+#include "network.h"
+
+#include "string_view"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <future>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace rpc {
+
+// This is not a cross platform serializer
+struct Serializer {
+  std::vector<char> buf;
+  void write(const void* data, size_t len) {
+    size_t offset = buf.size();
+    if (buf.capacity() < offset + len) {
+      buf.reserve(
+          std::max(offset + len, std::max(buf.capacity() * 2, (size_t)16)));
+    }
+    buf.resize(offset + len);
+    std::memcpy(buf.data() + offset, data, len);
+  }
+  template <typename T, std::enable_if_t<std::is_trivial_v<T>>* = nullptr>
+  void write(T v) {
+    write((void*)&v, sizeof(v));
+  }
+
+  void write(std::string_view str) {
+    write(str.size());
+    write(str.data(), str.size());
+  }
+
+  template <typename T> void write(std::basic_string_view<T> str) {
+    write(str.size());
+    write(str.data(), sizeof(T) * str.size());
+  }
+
+  void clear() {
+    buf.clear();
+  }
+  const char* data() const {
+    return buf.data();
+  }
+  size_t size() const {
+    return buf.size();
+  }
+
+  void compress(int level = 0) {
+    std::vector<char> newbuf;
+    newbuf.resize(sizeof(size_t) + ZSTD_compressBound(buf.size()));
+    auto n = ZSTD_compress(newbuf.data() + sizeof(size_t),
+                           newbuf.size() - sizeof(size_t), buf.data(),
+                           buf.size(), level);
+    if (!ZSTD_isError(n)) {
+      size_t sn = buf.size();
+      std::memcpy(newbuf.data(), &sn, sizeof(sn));
+      newbuf.resize(sizeof(size_t) + n);
+      std::swap(buf, newbuf);
+    } else {
+      buf.clear();
+    }
+  }
+};
+struct Deserializer {
+  std::string_view buf;
+  std::vector<char> ownbuf;
+  Deserializer() = default;
+  Deserializer(std::string_view buf)
+      : buf(buf) {
+  }
+  Deserializer(const void* data, size_t len)
+      : buf((const char*)data, len) {
+  }
+  void consume(size_t len) {
+    buf = {buf.data() + len, buf.size() - len};
+  }
+  template <typename T> std::basic_string_view<T> readStringView() {
+    size_t len = read<size_t>();
+    if (buf.size() < sizeof(T) * len) {
+      len = buf.size() / sizeof(T);
+    }
+    T* data = (T*)buf.data();
+    consume(sizeof(T) * len);
+    return {data, len};
+  }
+  std::string_view readString() {
+    size_t len = read<size_t>();
+    if (buf.size() < len) {
+      len = buf.size();
+    }
+    const char* data = buf.data();
+    consume(len);
+    return {data, len};
+  }
+  template <typename T, std::enable_if_t<std::is_trivial_v<T>>* = nullptr>
+  void read(T& r) {
+    if (buf.size() < sizeof(T)) {
+      consume(buf.size());
+      r = {};
+      return;
+    }
+    std::memcpy(&r, buf.data(), sizeof(T));
+    consume(sizeof(T));
+  }
+  void read(std::string_view& r) {
+    r = readString();
+  }
+  void read(std::string& r) {
+    r = readString();
+  }
+  template <typename T> void read(std::basic_string_view<T>& r) {
+    r = readStringView<T>();
+  }
+
+  template <typename T> T read() {
+    T r;
+    read(r);
+    return r;
+  }
+  std::string_view read() {
+    return readString();
+  }
+
+  bool empty() {
+    return buf.empty();
+  }
+
+  void decompress() {
+    size_t sn = read<size_t>();
+    std::vector<char> newbuf;
+    newbuf.resize(sn);
+    auto n =
+        ZSTD_decompress(newbuf.data(), newbuf.size(), buf.data(), buf.size());
+    if (!ZSTD_isError(n)) {
+      std::swap(ownbuf, newbuf);
+      buf = {ownbuf.data(), ownbuf.size()};
+    } else {
+      buf = {};
+    }
+  }
+};
+
+struct Serialize {
+  Serialize(Serializer& ser)
+      : ser(ser) {
+  }
+  Serializer& ser;
+
+  template <typename T> static std::false_type has_serialize_f(...);
+  template <typename T,
+            typename = decltype(
+                std::declval<T>().serialize(std::declval<Serialize&>()))>
+  static std::true_type has_serialize_f(int);
+  template <typename T>
+  static const bool has_serialize =
+      decltype(Serialize::has_serialize_f<T>(0))::value;
+  template <typename T> static std::false_type has_builtin_write_f(...);
+  template <
+      typename T,
+      typename = decltype(std::declval<Serializer>().write(std::declval<T>()))>
+  static std::true_type has_builtin_write_f(int);
+  template <typename T>
+  static const bool has_builtin_write =
+      decltype(Serialize::has_builtin_write_f<T>(0))::value;
+  template <typename T> void operator()(const T& v) {
+    if constexpr (has_serialize<const T>) {
+      v.serialize(*this);
+    } else if constexpr (has_builtin_write<const T>) {
+      ser.write(std::forward<const T>(v));
+    } else {
+      serialize(*this, std::forward<const T>(v));
+    }
+  }
+
+  template <typename... T> void operator()(const T&... v) {
+    (int[]){((*this)(std::forward<const T>(v)), 0)...};
+  }
+};
+
+struct Deserialize {
+  Deserialize(Deserializer& des)
+      : des(des) {
+  }
+  Deserializer& des;
+
+  template <typename T> static std::false_type has_serialize_f(...);
+  template <typename T,
+            typename = decltype(
+                std::declval<T>().serialize(std::declval<Deserialize&>()))>
+  static std::true_type has_serialize_f(int);
+  template <typename T>
+  static const bool has_serialize =
+      decltype(Deserialize::has_serialize_f<T>(0))::value;
+  template <typename T> static std::false_type has_builtin_read_f(...);
+  template <typename T,
+            typename =
+                decltype(std::declval<Deserializer>().read(std::declval<T&>()))>
+  static std::true_type has_builtin_read_f(int);
+  template <typename T>
+  static const bool has_builtin_read =
+      decltype(Deserialize::has_builtin_read_f<T>(0))::value;
+  template <typename T> void operator()(T& v) {
+    if constexpr (has_serialize<T>) {
+      v.serialize(*this);
+    } else if constexpr (has_builtin_read<T>) {
+      des.read(v);
+    } else {
+      serialize(*this, v);
+    }
+  }
+
+  template <typename... T> void operator()(T&... v) {
+    (int[]){((*this)(v), 0)...};
+  }
+
+  template <typename T> T read() {
+    if constexpr (has_serialize<T>) {
+      T r;
+      r.serialize(*this);
+      return r;
+    } else if constexpr (has_builtin_read<T>) {
+      return des.read<T>();
+    } else {
+      T r;
+      serialize(*this, r);
+      return r;
+    }
+  }
+};
+
+struct RPCException : std::exception {};
+
+struct RPCExceptionConnectionError : RPCException {
+  virtual const char* what() const noexcept override {
+    return "RPC connection error";
+  }
+};
+
+struct RPCExceptionFunctionNotFound : RPCException {
+  virtual const char* what() const noexcept override {
+    return "RPC function not found";
+  }
+};
+
+struct RPCExceptionRemoteException : RPCException {
+  virtual const char* what() const noexcept override {
+    return "RPC remote exception";
+  }
+};
+
+class Client : public std::enable_shared_from_this<Client> {
+ public:
+  Client() = default;
+  Client(network::Peer peer)
+      : peer(std::move(peer)) {
+    this->peer.setOnMessage([this](std::string_view buf) {
+      bytesReceived_ += buf.size();
+      Deserializer des(buf);
+      des.decompress();
+      Deserialize x(des);
+      uint32_t id;
+      uint8_t status;
+      x(id, status);
+      std::unique_lock l(reqmut);
+      auto i = requests.find(id);
+      if (i != requests.end()) {
+        auto r = std::move(i->second);
+        requests.erase(i);
+        l.unlock();
+        lastLatency_ = std::chrono::steady_clock::now() - r->timestamp;
+        if (status == 0xff) {
+          r->exception(std::make_exception_ptr(RPCExceptionFunctionNotFound()));
+        } else if (status == 0xfe) {
+          r->exception(std::make_exception_ptr(RPCExceptionRemoteException()));
+        } else if (status != 0) {
+          r->exception(std::make_exception_ptr(RPCExceptionConnectionError()));
+        } else {
+          r->handle(x);
+        }
+      }
+    });
+    this->peer.setOnConnectionClosed([this]() {
+      std::unique_lock l(reqmut);
+      for (auto& v : requests) {
+        v.second->exception(
+            std::make_exception_ptr(RPCExceptionConnectionError()));
+      }
+      requests.clear();
+    });
+  }
+  ~Client() {
+    peer.close();
+  }
+
+  void close() {
+    peer.close();
+  }
+
+  template <typename... Args>
+  void async(std::string_view funcname, Args&&... args) {
+    Serializer ser;
+    Serialize x(ser);
+    uint32_t id = ++reqcounter;
+    x(id, funcname, std::forward<Args>(args)...);
+    ser.compress();
+    peer.sendMessage(ser.data(), ser.size());
+    bytesSent_ += ser.size();
+    ++numRpcCalls_;
+  }
+
+  struct RequestBase {
+    std::chrono::steady_clock::time_point timestamp;
+    virtual ~RequestBase() {
+    }
+    virtual void handle(Deserialize&) noexcept = 0;
+    virtual void exception(std::exception_ptr e) noexcept = 0;
+  };
+
+  template <typename R> struct RequestImpl : RequestBase {
+    std::promise<R> p;
+    std::atomic_bool handled = false;
+    virtual ~RequestImpl() {
+    }
+    virtual void handle(Deserialize& x) noexcept override {
+      if (handled.exchange(true)) {
+        return;
+      }
+      if constexpr (std::is_same_v<void, R>) {
+        p.set_value();
+      } else {
+        R r;
+        x(r);
+        p.set_value(r);
+      }
+    }
+    virtual void exception(std::exception_ptr e) noexcept override {
+      if (handled.exchange(true)) {
+        return;
+      }
+      p.set_exception(e);
+    }
+  };
+
+  template <typename R, typename... Args>
+  std::future<R> async(std::string_view funcname, Args&&... args) {
+    Serializer ser;
+    Serialize x(ser);
+    uint32_t id = ++reqcounter;
+    x(id, funcname, std::forward<Args>(args)...);
+    auto req = std::make_unique<RequestImpl<R>>();
+    auto fut = req->p.get_future();
+    std::unique_lock l(reqmut);
+    req->timestamp = std::chrono::steady_clock::now();
+    requests[id] = std::move(req);
+    l.unlock();
+    ser.compress();
+    peer.sendMessage(ser.data(), ser.size());
+    bytesSent_ += ser.size();
+    ++numRpcCalls_;
+    return fut;
+  }
+
+  template <typename R, typename... Args>
+  R sync(std::string_view funcname, Args&&... args) {
+    auto f = async<R>(funcname, std::forward<Args>(args)...);
+    return f.get();
+  }
+
+  template <typename... Args>
+  void sync(std::string_view funcname, Args&&... args) {
+    return sync<void>(funcname, std::forward<Args>(args)...);
+  }
+
+  size_t bytesSent() const {
+    return bytesSent_;
+  }
+  size_t bytesReceived() const {
+    return bytesReceived_;
+  }
+  size_t numRpcCalls() const {
+    return numRpcCalls_;
+  }
+  std::chrono::steady_clock::duration lastLatency() const {
+    return lastLatency_;
+  }
+
+ private:
+  std::mutex reqmut;
+  std::unordered_map<uint32_t, std::unique_ptr<RequestBase>> requests;
+  std::atomic<uint32_t> reqcounter = 0;
+  network::Peer peer;
+
+  std::atomic_size_t bytesSent_ = 0;
+  std::atomic_size_t bytesReceived_ = 0;
+  std::atomic_size_t numRpcCalls_ = 0;
+  std::atomic<std::chrono::steady_clock::duration> lastLatency_{};
+};
+
+class Server {
+ public:
+  Server() = default;
+  Server(network::Server server)
+      : server(std::move(server)) {
+    this->server.setOnPeer([this](network::Peer peer) {
+      auto ref = std::make_shared<Peer>();
+      ref->peer = std::move(peer);
+      auto l = this->server.lock();
+      peers.push_back(ref);
+      l.unlock();
+      ref->peer.setOnMessage(
+          [this, ref](std::string_view buf) { handle(*ref, buf); });
+      ref->peer.setOnConnectionClosed([this, ref]() {
+        auto l = this->server.lock();
+        for (auto i = peers.begin(); i != peers.end(); ++i) {
+          if (*i == ref) {
+            peers.erase(i);
+            break;
+          }
+        }
+        ref->peer.post_close();
+      });
+    });
+  }
+  ~Server() {
+    server.close();
+    for (auto& v : peers) {
+      v->peer.close();
+    }
+    peers.clear();
+  }
+
+  Server(Server&&) = delete;
+  Server(Server&) = delete;
+
+  void listen(std::string_view endpoint) {
+    server.listen(endpoint);
+  }
+
+  struct FBase {
+    virtual ~FBase(){};
+    virtual void call(Deserialize& x, Serialize& sx) = 0;
+  };
+
+  template <typename R, typename... Args> struct FImpl : FBase {
+    std::function<R(Args...)> f;
+    FImpl(std::function<R(Args...)> f)
+        : f(std::move(f)) {
+    }
+    virtual ~FImpl(){};
+    virtual void call(Deserialize& x, Serialize& sx) override {
+      std::tuple<Args...> args;
+      unfold<0>(x, args);
+      if constexpr (std::is_same_v<void, R>) {
+        std::apply(f, std::move(args));
+      } else {
+        sx(std::apply(f, std::move(args)));
+      }
+    }
+    template <size_t n, typename T> void unfold(Deserialize& x, T& tuple) {
+      x(std::get<n>(tuple));
+      if constexpr (n + 1 != std::tuple_size_v<T>) {
+        unfold<n + 1>(x, tuple);
+      }
+    }
+  };
+
+  std::unordered_set<std::string> funcnames;
+  std::unordered_map<std::string_view, std::unique_ptr<FBase>> funcs;
+
+  template <typename R, typename... Args>
+  void define(std::string_view name, std::function<R(Args...)> f) {
+    auto ff = std::make_unique<FImpl<R, Args...>>(std::move(f));
+    funcs[*funcnames.emplace(name).first] = std::move(ff);
+  }
+
+  template <typename R, typename... Args>
+  void define(std::string_view name, R (*f)(Args...)) {
+    define(name, std::function<R(Args...)>(f));
+  }
+
+  template <typename R, typename M, typename... Args>
+  void define(std::string_view name, R (M::*f)(Args...), M* self) {
+    define(name, std::function<R(Args...)>([self, f](Args&&... args) -> R {
+             return (self->*f)(std::forward<Args>(args)...);
+           }));
+  }
+
+  template <typename R, typename... Args, typename T>
+  void define(std::string_view name, T f) {
+    auto ff = std::make_unique<FImpl<R, Args...>>(std::move(f));
+    funcs[*funcnames.emplace(name).first] = std::move(ff);
+  }
+
+  size_t bytesSent() const {
+    return bytesSent_;
+  }
+  size_t bytesReceived() const {
+    return bytesReceived_;
+  }
+  size_t numRpcCalls() const {
+    return numRpcCalls_;
+  }
+
+ private:
+  struct Peer {
+    network::Peer peer;
+  };
+
+  struct Message {
+    Message* next = nullptr;
+    std::vector<char> buf;
+  };
+
+  void handle(Peer& peer, std::string_view buf) {
+    bytesReceived_ += buf.size();
+    Deserializer des(buf.data(), buf.size());
+    des.decompress();
+    Deserialize x(des);
+    uint32_t id;
+    std::string_view name;
+    x(id, name);
+    Serializer ser;
+    Serialize sx(ser);
+    ++numRpcCalls_;
+    auto i = funcs.find(name);
+    if (i != funcs.end()) {
+      sx(id);
+      sx((uint8_t)0);
+      try {
+        i->second->call(x, sx);
+      } catch (...) {
+        ser.clear();
+        sx(id);
+        sx((uint8_t)0xfe);
+        ser.compress();
+        peer.peer.sendMessage(ser.data(), ser.size());
+        bytesSent_ += ser.size();
+        throw;
+      }
+    } else {
+      sx(id);
+      sx((uint8_t)0xff);
+    }
+    ser.compress();
+    peer.peer.sendMessage(ser.data(), ser.size());
+    bytesSent_ += ser.size();
+  }
+
+  network::Server server;
+  std::vector<std::shared_ptr<Peer>> peers;
+
+  std::atomic_size_t bytesSent_ = 0;
+  std::atomic_size_t bytesReceived_ = 0;
+  std::atomic_size_t numRpcCalls_ = 0;
+};
+
+class Rpc {
+ public:
+  Rpc() = default;
+  Rpc(Rpc&&) = delete;
+  Rpc(Rpc&) = delete;
+  ~Rpc() {
+    terminate = true;
+    for (auto& _ : threads) {
+      (void)_;
+      net.post([] {});
+    }
+  }
+
+  std::shared_ptr<Server> listen(std::string_view endpoint) {
+    return std::make_shared<Server>(net.listen(endpoint));
+  }
+
+  std::shared_ptr<Client> connect(std::string_view endpoint) {
+    return std::make_shared<Client>(net.connect(endpoint));
+  }
+
+  bool run_one() {
+    return net.run_one();
+  }
+
+  void asyncRun(int nThreads = 1) {
+    for (; nThreads; --nThreads) {
+      threads.emplace_back([this]() {
+        while (!terminate) {
+          net.run_one();
+        }
+      });
+    }
+  }
+
+ private:
+  network::Network net;
+
+  std::atomic_bool terminate = false;
+  std::vector<std::thread> threads;
+};
+
+}  // namespace rpc


### PR DESCRIPTION
This is for the most part a rewrite of the networking, replacing the old ZMQ-based approach with a new RPC interface built on top of ASIO for networking. It also supports sending the model weights over InfiniBand.

The tournament mode logic has also changed quite a bit with regards to how it samples models.
There is some new useful logging, showing how many games have ran between each ELO printout and how many in total - note that this only counts games used for ELO updates. The total number of games used for learning is usually substantially higher.
