### PR TITLE
[1/N] Ludii fix for big merge branch

### DIFF
--- a/src/games/ludii/jni_utils.cc
+++ b/src/games/ludii/jni_utils.cc
@@ -70,18 +70,20 @@ void JNIUtils::InitJVM(std::string jar_location) {
   JavaVMInitArgs vm_args;
 
 #ifdef CHECK_JNI
-  const size_t num_jvm_args = 2;
+  const size_t num_jvm_args = 3;
 #else
-  const size_t num_jvm_args = 1;
+  const size_t num_jvm_args = 2;
 #endif
 
   JavaVMOption options[num_jvm_args];
   std::string java_classpath = "-Djava.class.path=" + jar_location;
   options[0].optionString = java_classpath.data();
+  std::string heapdump_str = "-XX:+HeapDumpOnOutOfMemoryError";
+  options[1].optionString = heapdump_str.data();
 
 #ifdef CHECK_JNI
   std::string check_jni = "-Xcheck:jni";
-  options[1].optionString = check_jni.data();
+  options[2].optionString = check_jni.data();
 #endif
 
   vm_args.version = 0x00010002;

--- a/src/games/ludii/jni_utils.h
+++ b/src/games/ludii/jni_utils.h
@@ -41,7 +41,7 @@ class JNIUtils {
 
   static void CheckJniException(JNIEnv* jenv) {
     if (jenv->ExceptionCheck()) {
-      jenv->ExceptionDescribe(jenv);
+      jenv->ExceptionDescribe();
       jenv->ExceptionClear();
       printf("Java Exception at line %d of %s\n", __LINE__, __FILE__);
       throw std::runtime_error("Java exception thrown!");

--- a/src/games/ludii/jni_utils.h
+++ b/src/games/ludii/jni_utils.h
@@ -41,7 +41,7 @@ class JNIUtils {
 
   static void CheckJniException(JNIEnv* jenv) {
     if (jenv->ExceptionCheck()) {
-      jenv->ExceptionDescribe();
+      jenv->ExceptionDescribe(jenv);
       jenv->ExceptionClear();
       printf("Java Exception at line %d of %s\n", __LINE__, __FILE__);
       throw std::runtime_error("Java exception thrown!");

--- a/src/games/ludii/ludii_game_wrapper.cc
+++ b/src/games/ludii/ludii_game_wrapper.cc
@@ -27,8 +27,9 @@ LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path) {
   jclass ludiiGameWrapperClass = JNIUtils::LudiiGameWrapperClass();
 
   // Find the LudiiGameWrapper Java construct method
-  jmethodID ludiiGameWrapperConstruct = jenv->GetStaticMethodID(
-      ludiiGameWrapperClass, "construct", "(Ljava/lang/String;)Lutils/LudiiGameWrapper;");
+  jmethodID ludiiGameWrapperConstruct =
+      jenv->GetStaticMethodID(ludiiGameWrapperClass, "construct",
+                              "(Ljava/lang/String;)Lutils/LudiiGameWrapper;");
   JNIUtils::CheckJniException(jenv);
 
   // Convert our lud path into a Java string
@@ -76,7 +77,8 @@ LudiiGameWrapper::LudiiGameWrapper(
   // Find the LudiiGameWrapper Java construct method (with extra argument for
   // options)
   jmethodID ludiiGameWrapperConstruct = jenv->GetStaticMethodID(
-      ludiiGameWrapperClass, "construct", "(Ljava/lang/String;[Ljava/lang/String;)Lutils/LudiiGameWrapper;");
+      ludiiGameWrapperClass, "construct",
+      "(Ljava/lang/String;[Ljava/lang/String;)Lutils/LudiiGameWrapper;");
   JNIUtils::CheckJniException(jenv);
 
   // Convert our lud path into a Java string
@@ -95,7 +97,8 @@ LudiiGameWrapper::LudiiGameWrapper(
 
   // Call our Java construct method to instantiate new object
   jobject local_ref = jenv->CallStaticObjectMethod(
-      ludiiGameWrapperClass, ludiiGameWrapperConstruct, java_lud_path, java_game_options);
+      ludiiGameWrapperClass, ludiiGameWrapperConstruct, java_lud_path,
+      java_game_options);
   JNIUtils::CheckJniException(jenv);
   ludiiGameWrapperJavaObject = jenv->NewGlobalRef(local_ref);
   jenv->DeleteLocalRef(local_ref);

--- a/src/games/ludii/ludii_game_wrapper.cc
+++ b/src/games/ludii/ludii_game_wrapper.cc
@@ -26,18 +26,18 @@ LudiiGameWrapper::LudiiGameWrapper(const std::string lud_path) {
   JNIEnv* jenv = JNIUtils::GetEnv();
   jclass ludiiGameWrapperClass = JNIUtils::LudiiGameWrapperClass();
 
-  // Find the LudiiGameWrapper Java constructor
-  jmethodID ludiiGameWrapperConstructor = jenv->GetMethodID(
-      ludiiGameWrapperClass, "<init>", "(Ljava/lang/String;)V");
+  // Find the LudiiGameWrapper Java construct method
+  jmethodID ludiiGameWrapperConstruct = jenv->GetStaticMethodID(
+      ludiiGameWrapperClass, "construct", "(Ljava/lang/String;)Lutils/LudiiGameWrapper;");
   JNIUtils::CheckJniException(jenv);
 
   // Convert our lud path into a Java string
   jstring java_lud_path = jenv->NewStringUTF(lud_path.c_str());
   JNIUtils::CheckJniException(jenv);
 
-  // Call our Java constructor to instantiate new object
-  jobject local_ref = jenv->NewObject(
-      ludiiGameWrapperClass, ludiiGameWrapperConstructor, java_lud_path);
+  // Call our Java construct method to instantiate new object
+  jobject local_ref = jenv->CallStaticObjectMethod(
+      ludiiGameWrapperClass, ludiiGameWrapperConstruct, java_lud_path);
   JNIUtils::CheckJniException(jenv);
   ludiiGameWrapperJavaObject = jenv->NewGlobalRef(local_ref);
   jenv->DeleteLocalRef(local_ref);
@@ -73,11 +73,10 @@ LudiiGameWrapper::LudiiGameWrapper(
   JNIEnv* jenv = JNIUtils::GetEnv();
   jclass ludiiGameWrapperClass = JNIUtils::LudiiGameWrapperClass();
 
-  // Find the LudiiGameWrapper Java constructor (with extra argument for
+  // Find the LudiiGameWrapper Java construct method (with extra argument for
   // options)
-  jmethodID ludiiGameWrapperConstructor =
-      jenv->GetMethodID(ludiiGameWrapperClass, "<init>",
-                        "(Ljava/lang/String;[Ljava/lang/String;)V");
+  jmethodID ludiiGameWrapperConstruct = jenv->GetStaticMethodID(
+      ludiiGameWrapperClass, "construct", "(Ljava/lang/String;[Ljava/lang/String;)Lutils/LudiiGameWrapper;");
   JNIUtils::CheckJniException(jenv);
 
   // Convert our lud path into a Java string
@@ -94,10 +93,9 @@ LudiiGameWrapper::LudiiGameWrapper(
     JNIUtils::CheckJniException(jenv);
   }
 
-  // Call our Java constructor to instantiate new object
-  jobject local_ref =
-      jenv->NewObject(ludiiGameWrapperClass, ludiiGameWrapperConstructor,
-                      java_lud_path, java_game_options);
+  // Call our Java construct method to instantiate new object
+  jobject local_ref = jenv->CallStaticObjectMethod(
+      ludiiGameWrapperClass, ludiiGameWrapperConstruct, java_lud_path, java_game_options);
   JNIUtils::CheckJniException(jenv);
   ludiiGameWrapperJavaObject = jenv->NewGlobalRef(local_ref);
   jenv->DeleteLocalRef(local_ref);
@@ -124,10 +122,7 @@ LudiiGameWrapper::LudiiGameWrapper(
 
   // Clean up memory
   jenv->DeleteLocalRef(java_lud_path);
-  jenv->DeleteLocalRef(java_game_options);  // TODO see if we also need to clean
-                                            // elements of array first?
-
-  // TODO also handle the Game object caching with options
+  jenv->DeleteLocalRef(java_game_options);
 }
 
 LudiiGameWrapper::LudiiGameWrapper(LudiiGameWrapper const& other) {

--- a/src/games/ludii/ludii_state_wrapper.cc
+++ b/src/games/ludii/ludii_state_wrapper.cc
@@ -171,6 +171,9 @@ LudiiStateWrapper::LudiiStateWrapper(int seed,
   JNIUtils::CheckJniException(jenv);
   resetMethodID = jenv->GetMethodID(ludiiStateWrapperClass, "reset", "()V");
   JNIUtils::CheckJniException(jenv);
+  copyFromMethodID = 
+      jenv->GetMethodID(ludiiStateWrapperClass, "copyFrom", "(Lutils/LudiiStateWrapper;)V");
+  JNIUtils::CheckJniException(jenv);
 }
 
 LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
@@ -202,6 +205,31 @@ LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
   toTensorFlatMethodID = other.toTensorFlatMethodID;
   currentPlayerMethodID = other.currentPlayerMethodID;
   resetMethodID = other.resetMethodID;
+  copyFromMethodID = other.copyFromMethodID;
+}
+
+LudiiStateWrapper& LudiiStateWrapper::operator=(LudiiStateWrapper const& other) {
+  if (&other == this)
+    return *this;
+
+  core::State::operator=(other);
+
+  JNIEnv* jenv = JNIUtils::GetEnv();
+  jenv->CallVoidMethod(ludiiStateWrapperJavaObject, copyFromMethodID, other.ludiiStateWrapperJavaObject);
+  JNIUtils::CheckJniException(jenv);
+  
+  // We can just copy all the pointers to methods
+  legalMovesTensorsMethodID = other.legalMovesTensorsMethodID;
+  numLegalMovesMethodID = other.numLegalMovesMethodID;
+  applyNthMoveMethodID = other.applyNthMoveMethodID;
+  returnsMethodID = other.returnsMethodID;
+  isTerminalMethodID = other.isTerminalMethodID;
+  toTensorFlatMethodID = other.toTensorFlatMethodID;
+  currentPlayerMethodID = other.currentPlayerMethodID;
+  resetMethodID = other.resetMethodID;
+  copyFromMethodID = other.copyFromMethodID;
+  
+  return *this;
 }
 
 LudiiStateWrapper::~LudiiStateWrapper() {

--- a/src/games/ludii/ludii_state_wrapper.h
+++ b/src/games/ludii/ludii_state_wrapper.h
@@ -109,10 +109,7 @@ class LudiiStateWrapper : public core::State {
 
   virtual bool isOnePlayerGame() const override;
 
-  LudiiStateWrapper& operator=(LudiiStateWrapper const&) {
-    throw std::runtime_error("hi, this is ludii copy assignment operator");
-    return *this;
-  }
+  LudiiStateWrapper& operator=(LudiiStateWrapper const& other);
 
  private:
   void findFeatures();
@@ -152,6 +149,9 @@ class LudiiStateWrapper : public core::State {
 
   /** Method ID for the reset() method in Java */
   jmethodID resetMethodID;
+  
+  /** Method ID for the copyFrom() method in Java */
+  jmethodID copyFromMethodID;
 };
 
 }  // namespace Ludii


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Primary change is the correct implementation of `operator=` for `LudiiStateWrapper`, necessary to make Ludii games work correctly again with the big branch to be merged into master at a later date. 

Minor changes:
- Added "-XX:+HeapDumpOnOutOfMemoryError" to the JVM args, which means we'll now produce a heap dump whenever Java runs out of memory (might be useful for debugging)
- Switched to calling new static factory methods instead of constructors in Java for constructing Java's LudiiGameWrappers. On the Java end, these factory methods now keep track of a cache of previously-instantiated game objects and recycle those if possible.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
