### PR TITLE
[2/N] --game_options param for games (used by Ludii)

### DIFF
--- a/pypolygames/convert.py
+++ b/pypolygames/convert.py
@@ -32,6 +32,7 @@ def convert_checkpoint(
         checkpoint_path=model_params.init_checkpoint)
     old_model_params = checkpoint["model_params"]
     old_game_params = checkpoint["game_params"]
+    sanitize_game_params(old_game_params) # backwards compatibility for models without game_options
     model_state_dict = checkpoint["model_state_dict"]
 
     print(old_model_params.model_name)

--- a/pypolygames/env_creation_helpers.py
+++ b/pypolygames/env_creation_helpers.py
@@ -25,7 +25,7 @@ def sanitize_game_params(game_params: GameParams) -> None:
     game_params.per_thread_batchsize = 0
     
     # Many old models don't have the game_options attribute
-    if not hasattr(game_params, 'game_optipns'):
+    if not hasattr(game_params, 'game_options'):
         game_params.game_options = list()
 
 

--- a/pypolygames/env_creation_helpers.py
+++ b/pypolygames/env_creation_helpers.py
@@ -23,6 +23,10 @@ def sanitize_game_params(game_params: GameParams) -> None:
     # EDIT: now it a simulation parameter, but for retro-compatibility
     #  we keep that function
     game_params.per_thread_batchsize = 0
+    
+    # Many old models don't have the game_options attribute
+    if not hasattr(game_params, 'game_optipns'):
+        game_params.game_options = list()
 
 
 def create_game(
@@ -35,8 +39,17 @@ def create_game(
     predict_end_state: bool = False,
     predict_n_states: int = 0,
 ) -> polygames.Game:
+    # Many old models don't have the game_options attribute
+    if hasattr(game_params, 'game_options'):
+        game_options = game_params.game_options
+        if game_options is None:
+            game_options = list()
+    else:
+        game_options = list()
+
     return polygames.Game(
         game_params.game_name,
+        game_options,
         num_episode,
         seed,
         eval_mode,

--- a/pypolygames/params.py
+++ b/pypolygames/params.py
@@ -27,6 +27,7 @@ class ArgFields:
 @dataclass
 class GameParams:
     game_name: Optional[str] = None
+    game_options: List[str] = None
     out_features: bool = False
     turn_features: bool = False
     turn_features_mc: bool = False
@@ -48,6 +49,7 @@ class GameParams:
             getattr(self, field) == getattr(other_game_params, field)
             for field in {
                 "game_name",
+                "game_options",
                 "out_features",
                 "turn_features",
                 "turn_features_mc",
@@ -68,6 +70,14 @@ class GameParams:
                     type=str,
                     help="Game name - if left unspecified it will default to the game "
                     "that the model selected with '--model_name' refers to as default",
+                )
+            ),
+            game_options=ArgFields(
+                opts=dict(
+                    type=str,
+                    nargs="*",
+                    default=None,
+                    help="Optional list of extra options to customise the game.",
                 )
             ),
             out_features=ArgFields(

--- a/src/core/game.h
+++ b/src/core/game.h
@@ -247,18 +247,18 @@ to look into this) if the strategy is identical to knuth’s.
       JNIEnv* jni_env = Ludii::JNIUtils::GetEnv();
 
       if (jni_env) {
-		if (gameOptions.size() > 0) {
-		  Ludii::LudiiGameWrapper game_wrapper(ludii_name, gameOptions);
-		  for (const std::string option : gameOptions) {
-	        std::cout << "Using Game Option: " << option << std::endl;
-		  }
+        if (gameOptions.size() > 0) {
+          Ludii::LudiiGameWrapper game_wrapper(ludii_name, gameOptions);
+          for (const std::string option : gameOptions) {
+            std::cout << "Using Game Option: " << option << std::endl;
+          }
           state_ =
-            newState<Ludii::LudiiStateWrapper>(seed, std::move(game_wrapper));
-		} else {
-		  Ludii::LudiiGameWrapper game_wrapper(ludii_name);
+              newState<Ludii::LudiiStateWrapper>(seed, std::move(game_wrapper));
+        } else {
+          Ludii::LudiiGameWrapper game_wrapper(ludii_name);
           state_ =
-            newState<Ludii::LudiiStateWrapper>(seed, std::move(game_wrapper));
-		}
+              newState<Ludii::LudiiStateWrapper>(seed, std::move(game_wrapper));
+        }
       } else {
         // Probably means we couldn't find the Ludii.jar file
         throw std::runtime_error(

--- a/src/core/game.h
+++ b/src/core/game.h
@@ -62,7 +62,7 @@ class Game : public tube::EnvThread {
 
  public:
   Game(std::string gameName,
-       std::vector<std::string>> gameOptions,
+       std::vector<std::string> gameOptions,
        int numEpisode,
        int seed,
        bool evalMode,

--- a/src/core/game.h
+++ b/src/core/game.h
@@ -62,6 +62,7 @@ class Game : public tube::EnvThread {
 
  public:
   Game(std::string gameName,
+       std::vector<std::string>> gameOptions,
        int numEpisode,
        int seed,
        bool evalMode,
@@ -246,9 +247,15 @@ to look into this) if the strategy is identical to knuth’s.
       JNIEnv* jni_env = Ludii::JNIUtils::GetEnv();
 
       if (jni_env) {
-        Ludii::LudiiGameWrapper game_wrapper(ludii_name);
-        state_ =
+		if (gameOptions.size() > 0) {
+		  Ludii::LudiiGameWrapper game_wrapper(ludii_name, gameOptions);
+          state_ =
             newState<Ludii::LudiiStateWrapper>(seed, std::move(game_wrapper));
+		} else {
+		  Ludii::LudiiGameWrapper game_wrapper(ludii_name);
+          state_ =
+            newState<Ludii::LudiiStateWrapper>(seed, std::move(game_wrapper));
+		}
       } else {
         // Probably means we couldn't find the Ludii.jar file
         throw std::runtime_error(

--- a/src/core/game.h
+++ b/src/core/game.h
@@ -249,6 +249,9 @@ to look into this) if the strategy is identical to knuth’s.
       if (jni_env) {
 		if (gameOptions.size() > 0) {
 		  Ludii::LudiiGameWrapper game_wrapper(ludii_name, gameOptions);
+		  for (const std::string option : gameOptions) {
+	        std::cout << "Using Game Option: " << option << std::endl;
+		  }
           state_ =
             newState<Ludii::LudiiStateWrapper>(seed, std::move(game_wrapper));
 		} else {

--- a/src/core/pybind.cc
+++ b/src/core/pybind.cc
@@ -22,7 +22,7 @@ PYBIND11_MODULE(polygames, m) {
   m.def("init_threads", &threads::init);
 
   py::class_<Game, tube::EnvThread, std::shared_ptr<Game>>(m, "Game")
-      .def(py::init<std::string, int, int, bool, bool, bool, bool, bool, int,
+      .def(py::init<std::string, std::vector<std::string>>, int, int, bool, bool, bool, bool, bool, int,
                     int, bool, int, int, bool, int>())
       .def("add_player", &Game::addPlayer, py::keep_alive<1, 2>())
       .def("add_eval_player", &Game::addEvalPlayer)

--- a/src/core/pybind.cc
+++ b/src/core/pybind.cc
@@ -22,7 +22,7 @@ PYBIND11_MODULE(polygames, m) {
   m.def("init_threads", &threads::init);
 
   py::class_<Game, tube::EnvThread, std::shared_ptr<Game>>(m, "Game")
-      .def(py::init<std::string, std::vector<std::string>>, int, int, bool, bool, bool, bool, bool, int,
+      .def(py::init<std::string, std::vector<std::string>, int, int, bool, bool, bool, bool, bool, int,
                     int, bool, int, int, bool, int>())
       .def("add_player", &Game::addPlayer, py::keep_alive<1, 2>())
       .def("add_eval_player", &Game::addEvalPlayer)

--- a/src/games/ludii/ludii_game_wrapper.cc
+++ b/src/games/ludii/ludii_game_wrapper.cc
@@ -90,7 +90,7 @@ LudiiGameWrapper::LudiiGameWrapper(
       game_options.size(), jenv->FindClass("java/lang/String"), nullptr);
   JNIUtils::CheckJniException(jenv);
   for (size_t i = 0; i < game_options.size(); ++i) {
-	jstring jstr = jenv->NewStringUTF(game_options[i].c_str());
+    jstring jstr = jenv->NewStringUTF(game_options[i].c_str());
     jenv->SetObjectArrayElement(java_game_options, i, jstr);
     jenv->DeleteLocalRef(jstr);
   }

--- a/src/games/ludii/ludii_game_wrapper.cc
+++ b/src/games/ludii/ludii_game_wrapper.cc
@@ -88,9 +88,9 @@ LudiiGameWrapper::LudiiGameWrapper(
       game_options.size(), jenv->FindClass("java/lang/String"), nullptr);
   JNIUtils::CheckJniException(jenv);
   for (size_t i = 0; i < game_options.size(); ++i) {
-    jenv->SetObjectArrayElement(
-        java_game_options, i, jenv->NewStringUTF(game_options[i].c_str()));
-    JNIUtils::CheckJniException(jenv);
+	jstring jstr = jenv->NewStringUTF(game_options[i].c_str());
+    jenv->SetObjectArrayElement(java_game_options, i, jstr);
+    jenv->DeleteLocalRef(jstr);
   }
 
   // Call our Java construct method to instantiate new object


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Allows easy loading of variants of games through Ludii's options mechanism. For example, `--game_name="LudiiHex.lud"` just loads normal Hex, but `--game_name="LudiiHex.lud" --game_options "Board Size/13x13" "End Rules/Misere"` loads Hex on a 13x13 board with Misere rules.

I imagine the same mechanism could also be useful for non-Ludii games later on.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
