### PR TITLE
[6/N] cross-game transfer functionality in convert script

### DIFF
--- a/pypolygames/__main__.py
+++ b/pypolygames/__main__.py
@@ -128,6 +128,20 @@ def parse_args() -> argparse.Namespace:
         '--auto_tune_nnsize', action="store_true",
         help='Tune nnsize automatically such that number of filters in hidden layers remains unchanged.'
     )
+    parser_convert.add_argument(
+        '--zero_shot', type=bool, default=False, 
+        help='Convert for zero-shot evaluation without training; this will initialise any skipped or new params to 0.'
+    )
+    parser_convert.add_argument(
+        '--move_source_channels', type=int, nargs="*", 
+        help=('For fully convolutional architectures, for every channel in the destination game\'s move tensors, '
+              'specify the channel from the original tensor that we should transfer weights from.')
+    )
+    parser_convert.add_argument(
+        '--state_source_channels', type=int, nargs="*", 
+        help=('For fully convolutional architectures, for every channel in the destination game\'s state tensors, '
+              'specify the channel from the original tensor that we should transfer weights from.')
+    )
     
     # DRAW MODEL COMMAND
     parser_draw_model = subparsers.add_parser("draw_model")
@@ -416,6 +430,9 @@ def convert_checkpoint_from_args(args: argparse.Namespace):
         out=args.out,
         skip=args.skip,
         auto_tune_nnsize=args.auto_tune_nnsize,
+        zero_shot=args.zero_shot,
+        move_source_channels=args.move_source_channels,
+        state_source_channels=args.state_source_channels,
     )
     
 def draw_model_from_args(args: argparse.Namespace):


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

I've added three new arguments to convert script:

1. **--zero_shot**: I intend to use this when converting models purely for zero-shot transfer experiments. This should make sure that any new params that get added or reinitialised are initialised to 0, as opposed to small random numbers. This is bad for training afterwards, but might give slightly better performance for pure zero-shot transfer without any learning.

2. **--move_source_channels**: This should be a list of ints, of length `n`, where `n` is the number of channels for move tensors in the game that the model should function for *after* convert. For the final `Conv2d` operation that produces the logits, we'll loop through these `n` channels, and all the weights associated with channel `i` in the new game will be transferred from those associated with the channel indexed by the `ith` entry of the given list. (see example below)

3. **--state_source_channels**: This should be a list of ints, of length `n`, where `n` is the number of channels for state tensors in the game that the model should function for *after* convert. For the very first `Conv2d` operation that is applied to the state input tensor, we'll loop through these `n` channels, and all the weights associated with channel `i` in the new game will be transferred from those associated with the channel indexed by the `ith` entry of the given list. (see example below)

I can add more documentation about how all this works to the README later.

**Example for state channels**: 
In Ludii, *Yavalath* has 10 state channels, and *Gomoku* has 9. They are almost exactly the same, except the channel indexed by `4` in Yavalath has no matching channel in Gomoku (it's related to swap moves which don't exist in Gomoku).

If I want to transfer from Gomoku to Yavalath, I use the following, where `-1` indicates that that's a new channel in Yavalath for which I don't have anything that I want to transfer into it (just leave at default initialisation): `--state_source_channels 0 1 2 3 -1 4 5 6 7 8`

If I want to transfer from Yavalath to Gomoku, I skip over `4` because that's a channel that has become useless and I don't want to transfer anything from it, but I do want to transfer weights from the other channels: `--state_source_channels 0 1 2 3 5 6 7 8 9`

**Example for move channels**:
In Ludii, *Gomoku* has only 3 move channels, whereas *Dai Hasami Shogi* has 51 move channels. The final two channels for each are semantically equivalent. The first 49 channels in Dai Hasami Shogi should all be initialised with the same weights as the very first channel of Gomoku. This can be achieved by using: `--move_source_channels 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 2`

If we want to transfer from Dai Hasami Shogi, we do not know which weights to transfer for the very first channel, so we just reinitialise those by using `-1`, but we do know we can transfer the final two channels: `--move_source_channels -1 49 50`

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
