### PR TITLE
[7/N] Reset optimizer state

### DIFF
--- a/pypolygames/params.py
+++ b/pypolygames/params.py
@@ -324,6 +324,7 @@ class OptimParams:
     lr: float = 1e-3
     eps: float = 1.5e-4
     grad_clip: float = 0.25
+    reset_optimizer_state: bool = False
 
     def __setattr__(self, attr, value):
         if value is None:
@@ -354,6 +355,12 @@ class OptimParams:
             ),
             grad_clip=ArgFields(
                 opts=dict(type=float, help=f"Max norm of the gradients")
+            ),
+            reset_optimizer_state=ArgFields(
+                opts=dict(
+                    action="store_false" if cls.reset_optimizer_state else "store_true",
+                    help="If set, any internal state of optimizer from checkpoint will be reset"
+                )
             ),
         )
         for param, arg_field in params.items():

--- a/pypolygames/training.py
+++ b/pypolygames/training.py
@@ -45,7 +45,7 @@ def create_optimizer(
     optim = torch.optim.Adam(
         model.parameters(), lr=optim_params.lr, eps=optim_params.eps
     )
-    if optim_state_dict is not None:
+    if optim_state_dict is not None and not optim_params.reset_optimizer_state:
         try:
             optim.load_state_dict(optim_state_dict)
         except ValueError:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Added a `--reset_optimizer_state` OptimParam, which prevents loading of saved internal state of optimizer even if we resume training for a checkpoint. This is necessary to avoid crashes if we start training a checkpoint that was converted from a different game with different number of channels, and may also still be useful in some cases even if it's not necessary to avoid crashes.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

Training proceeds without crashing with this.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
