### PR TITLE
[8/N] Let Ludii run rollouts inside Java for pure MCTS

### DIFF
--- a/src/core/actor.h
+++ b/src/core/actor.h
@@ -147,6 +147,9 @@ class Actor {
   }
 
   void batchResize(size_t n) {
+    if (!modelManager_) {
+      return;
+    }
     if (!batchFeat_.defined() || batchFeat_[0].sizes() != feat_->data.sizes() ||
         batchFeat_.size(0) < n) {
       auto allocBatch = [&](auto&& sizes) {

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -246,7 +246,7 @@ class State {
             _status == GameStatus::player1Win);
   };
 
-  float getRandomRolloutReward(int player) const {
+  virtual float getRandomRolloutReward(int player) const {
     const int numSimulation = 10;
     float sumReward = 0.0;
     for (int i = 0; i < numSimulation; ++i) {

--- a/src/games/ludii/ludii_state_wrapper.cc
+++ b/src/games/ludii/ludii_state_wrapper.cc
@@ -174,7 +174,7 @@ LudiiStateWrapper::LudiiStateWrapper(int seed,
   copyFromMethodID = 
       jenv->GetMethodID(ludiiStateWrapperClass, "copyFrom", "(Lutils/LudiiStateWrapper;)V");
   JNIUtils::CheckJniException(jenv);
-  getRandomRolloutsRewardMethodID -
+  getRandomRolloutsRewardMethodID =
       jenv->GetMethodID(ludiiStateWrapperClass, "getRandomRolloutsReward", "(III)D");
   JNIUtils::CheckJniException(jenv);
 }

--- a/src/games/ludii/ludii_state_wrapper.cc
+++ b/src/games/ludii/ludii_state_wrapper.cc
@@ -174,6 +174,9 @@ LudiiStateWrapper::LudiiStateWrapper(int seed,
   copyFromMethodID = 
       jenv->GetMethodID(ludiiStateWrapperClass, "copyFrom", "(Lutils/LudiiStateWrapper;)V");
   JNIUtils::CheckJniException(jenv);
+  getRandomRolloutsRewardMethodID -
+      jenv->GetMethodID(ludiiStateWrapperClass, "getRandomRolloutsReward", "(III)D");
+  JNIUtils::CheckJniException(jenv);
 }
 
 LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
@@ -206,6 +209,7 @@ LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
   currentPlayerMethodID = other.currentPlayerMethodID;
   resetMethodID = other.resetMethodID;
   copyFromMethodID = other.copyFromMethodID;
+  getRandomRolloutsRewardMethodID = other.getRandomRolloutsRewardMethodID;
 }
 
 LudiiStateWrapper& LudiiStateWrapper::operator=(LudiiStateWrapper const& other) {
@@ -228,6 +232,7 @@ LudiiStateWrapper& LudiiStateWrapper::operator=(LudiiStateWrapper const& other) 
   currentPlayerMethodID = other.currentPlayerMethodID;
   resetMethodID = other.resetMethodID;
   copyFromMethodID = other.copyFromMethodID;
+  getRandomRolloutsRewardMethodID = other.getRandomRolloutsRewardMethodID;
   
   return *this;
 }
@@ -311,6 +316,16 @@ void LudiiStateWrapper::Reset() const {
 
 bool LudiiStateWrapper::isOnePlayerGame() const {
   return (ludiiGameWrapper->NumPlayers() == 1);
+}
+
+float LudiiStateWrapper::getRandomRolloutReward(int player) const {
+  const int numSimulation = 10;
+  const int rolloutRandomMovesCap = 200;	// Use -1 for no cap on num moves in rollout
+  JNIEnv* jenv = JNIUtils::GetEnv();
+  const double avgReward = (double)jenv->CallDoubleMethod(
+      ludiiStateWrapperJavaObject, getRandomRolloutsRewardMethodID, player, numSimulation, rolloutRandomMovesCap);
+  JNIUtils::CheckJniException(jenv);
+  return (float) avgReward;
 }
 
 }  // namespace Ludii

--- a/src/games/ludii/ludii_state_wrapper.cc
+++ b/src/games/ludii/ludii_state_wrapper.cc
@@ -171,11 +171,11 @@ LudiiStateWrapper::LudiiStateWrapper(int seed,
   JNIUtils::CheckJniException(jenv);
   resetMethodID = jenv->GetMethodID(ludiiStateWrapperClass, "reset", "()V");
   JNIUtils::CheckJniException(jenv);
-  copyFromMethodID = 
-      jenv->GetMethodID(ludiiStateWrapperClass, "copyFrom", "(Lutils/LudiiStateWrapper;)V");
+  copyFromMethodID = jenv->GetMethodID(
+      ludiiStateWrapperClass, "copyFrom", "(Lutils/LudiiStateWrapper;)V");
   JNIUtils::CheckJniException(jenv);
-  getRandomRolloutsRewardMethodID =
-      jenv->GetMethodID(ludiiStateWrapperClass, "getRandomRolloutsReward", "(III)D");
+  getRandomRolloutsRewardMethodID = jenv->GetMethodID(
+      ludiiStateWrapperClass, "getRandomRolloutsReward", "(III)D");
   JNIUtils::CheckJniException(jenv);
 }
 
@@ -212,16 +212,18 @@ LudiiStateWrapper::LudiiStateWrapper(const LudiiStateWrapper& other)
   getRandomRolloutsRewardMethodID = other.getRandomRolloutsRewardMethodID;
 }
 
-LudiiStateWrapper& LudiiStateWrapper::operator=(LudiiStateWrapper const& other) {
+LudiiStateWrapper& LudiiStateWrapper::operator=(
+    LudiiStateWrapper const& other) {
   if (&other == this)
     return *this;
 
   core::State::operator=(other);
 
   JNIEnv* jenv = JNIUtils::GetEnv();
-  jenv->CallVoidMethod(ludiiStateWrapperJavaObject, copyFromMethodID, other.ludiiStateWrapperJavaObject);
+  jenv->CallVoidMethod(ludiiStateWrapperJavaObject, copyFromMethodID,
+                       other.ludiiStateWrapperJavaObject);
   JNIUtils::CheckJniException(jenv);
-  
+
   // We can just copy all the pointers to methods
   legalMovesTensorsMethodID = other.legalMovesTensorsMethodID;
   numLegalMovesMethodID = other.numLegalMovesMethodID;
@@ -233,7 +235,7 @@ LudiiStateWrapper& LudiiStateWrapper::operator=(LudiiStateWrapper const& other) 
   resetMethodID = other.resetMethodID;
   copyFromMethodID = other.copyFromMethodID;
   getRandomRolloutsRewardMethodID = other.getRandomRolloutsRewardMethodID;
-  
+
   return *this;
 }
 
@@ -320,12 +322,14 @@ bool LudiiStateWrapper::isOnePlayerGame() const {
 
 float LudiiStateWrapper::getRandomRolloutReward(int player) const {
   const int numSimulation = 10;
-  const int rolloutRandomMovesCap = 200;	// Use -1 for no cap on num moves in rollout
+  const int rolloutRandomMovesCap =
+      200;  // Use -1 for no cap on num moves in rollout
   JNIEnv* jenv = JNIUtils::GetEnv();
   const double avgReward = (double)jenv->CallDoubleMethod(
-      ludiiStateWrapperJavaObject, getRandomRolloutsRewardMethodID, player, numSimulation, rolloutRandomMovesCap);
+      ludiiStateWrapperJavaObject, getRandomRolloutsRewardMethodID, player,
+      numSimulation, rolloutRandomMovesCap);
   JNIUtils::CheckJniException(jenv);
-  return (float) avgReward;
+  return (float)avgReward;
 }
 
 }  // namespace Ludii

--- a/src/games/ludii/ludii_state_wrapper.h
+++ b/src/games/ludii/ludii_state_wrapper.h
@@ -108,6 +108,8 @@ class LudiiStateWrapper : public core::State {
   void Reset() const;
 
   virtual bool isOnePlayerGame() const override;
+  
+  virtual float getRandomRolloutReward(int player) const override;
 
   LudiiStateWrapper& operator=(LudiiStateWrapper const& other);
 
@@ -152,6 +154,9 @@ class LudiiStateWrapper : public core::State {
   
   /** Method ID for the copyFrom() method in Java */
   jmethodID copyFromMethodID;
+  
+  /** Method ID for the getRandomRolloutsReward() method in Java */
+  jmethodID getRandomRolloutsRewardMethodID;
 };
 
 }  // namespace Ludii

--- a/src/games/ludii/ludii_state_wrapper.h
+++ b/src/games/ludii/ludii_state_wrapper.h
@@ -108,7 +108,7 @@ class LudiiStateWrapper : public core::State {
   void Reset() const;
 
   virtual bool isOnePlayerGame() const override;
-  
+
   virtual float getRandomRolloutReward(int player) const override;
 
   LudiiStateWrapper& operator=(LudiiStateWrapper const& other);
@@ -151,10 +151,10 @@ class LudiiStateWrapper : public core::State {
 
   /** Method ID for the reset() method in Java */
   jmethodID resetMethodID;
-  
+
   /** Method ID for the copyFrom() method in Java */
   jmethodID copyFromMethodID;
-  
+
   /** Method ID for the getRandomRolloutsReward() method in Java */
   jmethodID getRandomRolloutsRewardMethodID;
 };

--- a/src/mcts/mcts.cc
+++ b/src/mcts/mcts.cc
@@ -107,7 +107,7 @@ Action pickBestAction(int rootPlayerId,
   }
 
   if (sample) {
-    return sampleDiscreteProbability(pi.size(), 1.0f,
+    return sampleDiscreteProbability(pi.size(),
                                      [&](size_t index) {
                                        float score = getScore(
                                            index, node->getChild(index));

--- a/src/mcts/utils.h
+++ b/src/mcts/utils.h
@@ -177,6 +177,23 @@ size_t sampleDiscreteProbability(size_t nElements,
          probs.begin();
 }
 
+template <typename F, typename Rng>
+size_t sampleDiscreteProbability(size_t nElements, F&& getValue, Rng& rng) {
+  if (nElements == 0) {
+    throw std::runtime_error("sampleDiscreteProbability was passed 0 elements");
+  }
+  thread_local std::vector<float> probs;
+  probs.resize(nElements);
+  float sum = 0.0f;
+  for (size_t i = 0; i != nElements; ++i) {
+    sum += getValue(i);
+    probs[i] = sum;
+  }
+  float v = std::uniform_real_distribution<float>(0.0f, sum)(rng);
+  return std::lower_bound(probs.begin(), std::prev(probs.end()), v) -
+         probs.begin();
+}
+
 class MctsResult {
  public:
   MctsResult() = default;


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

For Ludii games, we override `getRandomRolloutReward()` (used by pure MCTS) such that we only call into Java once, and the random rollouts are fully executed inside Java, to avoid constantly switching back and forth between C++ code and Java code for every individual step in a random rollout. This also allows Ludii to use some of its optimised custom playout implementations that it has available for various games.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
