### PR TITLE
ZSTD, prevent interference with system zstd

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ add_subdirectory(mcts)
 file(GLOB _zstd_SOURCES third_party/zstd/lib/common/*.c third_party/zstd/lib/compress/*.c third_party/zstd/lib/decompress/*.c)
 add_library(_zstd OBJECT ${_zstd_SOURCES})
 
-target_include_directories(_zstd PUBLIC third_party/zstd/lib third_party/zstd/lib/common)
+target_include_directories(_zstd BEFORE PUBLIC third_party/zstd/lib third_party/zstd/lib/common)
 
 find_path(IBV_INCLUDE_DIR infiniband/verbs.h)
 find_library(IBV_LIBRARY ibverbs)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Force our zstd to actually use our zstd headers instead of any the user may have installed on the system.
